### PR TITLE
Improve Wayback query handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ python Night_Watcher.py --web
 
 ## 🎯 Key Features
 
-- **Multi-source collection** from 12+ verified RSS feeds
+ - **Multi-source collection** from verified news outlets and official government feeds
 - **7-round analysis pipeline** for deep content understanding
 - **Knowledge graph** tracking entities and relationships
 - **Vector search** for finding similar patterns
@@ -164,6 +164,8 @@ Each article goes through 7 rounds of analysis:
 - Normal - some feeds may be temporarily down
 - System continues with working feeds
 - Add new sources via web dashboard
+- For Wayback queries the collector uses the `site_domain` specified in a
+  source entry. If omitted, the domain is derived from the first article link.
 
 ### Out of Memory
 - Reduce `article_limit` in config.json

--- a/config.json
+++ b/config.json
@@ -7,6 +7,7 @@
         "type": "rss",
         "bias": "center",
         "name": "AP News Politics",
+        "site_domain": "apnews.com",
         "enabled": true
       },
       {
@@ -14,6 +15,7 @@
         "type": "rss",
         "bias": "center-left",
         "name": "NPR Politics",
+        "site_domain": "npr.org",
         "enabled": true
       },
       {
@@ -21,6 +23,7 @@
         "type": "rss",
         "bias": "center",
         "name": "Politico Top Picks",
+        "site_domain": "politico.com",
         "enabled": true
       },
       {
@@ -28,6 +31,7 @@
         "type": "rss",
         "bias": "center",
         "name": "The Hill",
+        "site_domain": "thehill.com",
         "enabled": true
       },
       {
@@ -35,6 +39,7 @@
         "type": "rss",
         "bias": "center",
         "name": "Reuters US",
+        "site_domain": "reuters.com",
         "enabled": true
       },
       {
@@ -42,6 +47,7 @@
         "type": "rss",
         "bias": "center-left",
         "name": "ProPublica",
+        "site_domain": "propublica.org",
         "enabled": true
       },
       {
@@ -49,6 +55,7 @@
         "type": "rss",
         "bias": "left",
         "name": "Democracy Now",
+        "site_domain": "democracynow.org",
         "enabled": true
       },
       {
@@ -56,6 +63,31 @@
         "type": "rss",
         "bias": "libertarian",
         "name": "Reason Magazine",
+        "site_domain": "reason.com",
+        "enabled": true
+      },
+      {
+        "url": "https://www.whitehouse.gov/briefing-room/statements-releases/feed/",
+        "type": "rss",
+        "bias": "official",
+        "name": "White House Press Releases",
+        "site_domain": "whitehouse.gov",
+        "enabled": true
+      },
+      {
+        "url": "https://www.supremecourt.gov/rss/opinions.xml",
+        "type": "rss",
+        "bias": "official",
+        "name": "Supreme Court Opinions",
+        "site_domain": "supremecourt.gov",
+        "enabled": true
+      },
+      {
+        "url": "https://www.justice.gov/feeds/press_releases/rss.xml",
+        "type": "rss",
+        "bias": "official",
+        "name": "DOJ Press Releases",
+        "site_domain": "justice.gov",
         "enabled": true
       }
     ],

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ A streamlined system for analyzing news and identifying authoritarian patterns w
 
 ## Overview
 
-Night_watcher is an intelligence gathering and analysis tool designed to monitor political content for authoritarian patterns. It collects articles from news sources, analyzes them for manipulation techniques and authoritarian indicators, and builds a knowledge base of patterns over time.
+Night_watcher is an intelligence gathering and analysis tool designed to monitor political content for authoritarian patterns. It collects articles from news sources and official government feeds, analyzes them for manipulation techniques and authoritarian indicators, and builds a knowledge base of patterns over time.
 
 ## Quick Start
 
@@ -98,8 +98,11 @@ python night_watcher.py --llm-host http://192.168.1.100:1234 --article-limit 20 
 
 ## Configuration
 
-The default configuration will be created automatically on first run. 
-To customize, edit the generated `config.json` file.
+The default configuration will be created automatically on first run.
+To customize, edit the generated `config.json` file.  Each RSS source may
+optionally define a `site_domain` field.  When collecting articles the
+collector derives the base domain for Wayback queries from this field.  If it
+is not provided, the domain is taken from the first article link.
 
 ## Output Structure
 
@@ -114,7 +117,7 @@ After running, you'll find the following in your output directory:
 
 ## Security Considerations
 
-- The framework runs locally with no external API calls except to specified news sources
+ - The framework runs locally with no external API calls except to specified news and government sources
 - All LLM interactions happen locally through LM Studio (or optionally via Anthropic API)
 - Documents are stored with cryptographic provenance to prevent tampering
 - No data is sent to external servers unless using Anthropic API


### PR DESCRIPTION
## Summary
- derive domain for each article from `site_domain` or article URL
- query Wayback Machine using that domain
- document how the domain for Wayback queries is chosen
- update example configuration with `site_domain` values
- include official government sources for reliability

## Testing
- `python -m py_compile collector.py`
- `python -m py_compile Night_Watcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68424a35fbb483328fc19774eca024ce