### PR TITLE
Add per-source article limit controls

### DIFF
--- a/Night_Watcher.py
+++ b/Night_Watcher.py
@@ -80,7 +80,8 @@ class NightWatcher:
                         "type": "rss",
                         "bias": "center",
                         "name": "BBC US & Canada",
-                        "enabled": True
+                        "enabled": True,
+                        "limit": 50
                     }
                 ],
                 "govt_keywords": [

--- a/collector.py
+++ b/collector.py
@@ -120,9 +120,10 @@ class ContentCollector:
         for source in self.sources:
             if not source.get("enabled", True):
                 continue
-                
+
             try:
-                articles = self._collect_from_source(source, start_date, end_date)
+                limit = source.get("limit", self.article_limit)
+                articles = self._collect_from_source(source, start_date, end_date, limit)
                 
                 # Filter by inauguration day if first run
                 if mode == "first_run":
@@ -180,7 +181,7 @@ class ContentCollector:
         except:
             return ("incremental", current_time - timedelta(days=1), current_time)
 
-    def _collect_from_source(self, source: Dict[str, Any], start_date: datetime, end_date: datetime) -> List[Dict[str, Any]]:
+    def _collect_from_source(self, source: Dict[str, Any], start_date: datetime, end_date: datetime, limit: int) -> List[Dict[str, Any]]:
         """Collect from a single source."""
         url = source.get("url", "")
 
@@ -199,7 +200,7 @@ class ContentCollector:
             feed = feedparser.parse(url, agent=random.choice(self.user_agents))
             articles = []
             
-            for entry in feed.entries[:self.article_limit]:
+            for entry in feed.entries[:limit]:
                 if not entry.get("link"):
                     continue
                 

--- a/config.json
+++ b/config.json
@@ -8,7 +8,8 @@
         "bias": "center",
         "name": "AP News Politics",
         "site_domain": "apnews.com",
-        "enabled": true
+        "enabled": true,
+        "limit": 50
       },
       {
         "url": "https://feeds.npr.org/1004/rss.xml",
@@ -16,7 +17,8 @@
         "bias": "center-left",
         "name": "NPR Politics",
         "site_domain": "npr.org",
-        "enabled": true
+        "enabled": true,
+        "limit": 50
       },
       {
         "url": "https://www.politico.com/rss/politicopicks.xml",
@@ -24,7 +26,8 @@
         "bias": "center",
         "name": "Politico Top Picks",
         "site_domain": "politico.com",
-        "enabled": true
+        "enabled": true,
+        "limit": 50
       },
       {
         "url": "https://thehill.com/feed/",
@@ -32,7 +35,8 @@
         "bias": "center",
         "name": "The Hill",
         "site_domain": "thehill.com",
-        "enabled": true
+        "enabled": true,
+        "limit": 50
       },
       {
         "url": "https://www.reuters.com/world/us/rss",
@@ -40,7 +44,8 @@
         "bias": "center",
         "name": "Reuters US",
         "site_domain": "reuters.com",
-        "enabled": true
+        "enabled": true,
+        "limit": 50
       },
       {
         "url": "https://www.propublica.org/feeds/propublica/main",
@@ -48,7 +53,8 @@
         "bias": "center-left",
         "name": "ProPublica",
         "site_domain": "propublica.org",
-        "enabled": true
+        "enabled": true,
+        "limit": 50
       },
       {
         "url": "https://www.democracynow.org/democracynow.rss",
@@ -56,7 +62,8 @@
         "bias": "left",
         "name": "Democracy Now",
         "site_domain": "democracynow.org",
-        "enabled": true
+        "enabled": true,
+        "limit": 50
       },
       {
         "url": "https://reason.com/feed/",
@@ -64,7 +71,8 @@
         "bias": "libertarian",
         "name": "Reason Magazine",
         "site_domain": "reason.com",
-        "enabled": true
+        "enabled": true,
+        "limit": 50
       },
       {
         "url": "https://www.whitehouse.gov/briefing-room/statements-releases/feed/",
@@ -72,7 +80,8 @@
         "bias": "official",
         "name": "White House Press Releases",
         "site_domain": "whitehouse.gov",
-        "enabled": true
+        "enabled": true,
+        "limit": 50
       },
       {
         "url": "https://www.supremecourt.gov/rss/opinions.xml",
@@ -80,7 +89,8 @@
         "bias": "official",
         "name": "Supreme Court Opinions",
         "site_domain": "supremecourt.gov",
-        "enabled": true
+        "enabled": true,
+        "limit": 50
       },
       {
         "url": "https://www.justice.gov/feeds/press_releases/rss.xml",
@@ -88,7 +98,8 @@
         "bias": "official",
         "name": "DOJ Press Releases",
         "site_domain": "justice.gov",
-        "enabled": true
+        "enabled": true,
+        "limit": 50
       }
     ],
     "govt_keywords": [

--- a/night_watcher_dashboard.html
+++ b/night_watcher_dashboard.html
@@ -463,6 +463,11 @@
                         <button class="btn btn-warning" onclick="testLLMConnection()">Test LLM Connection</button>
                         <button class="btn btn-primary" onclick="refreshStatus()">Refresh Status</button>
                     </div>
+
+                    <div class="control-panel">
+                        <h3>Source Limits</h3>
+                        <div id="sources-list"></div>
+                    </div>
                 </div>
 
                 <div class="progress-bar">
@@ -669,6 +674,7 @@
             startStatusPolling();
             loadTemplates();
             refreshReviewQueue();
+            loadSources();
         });
 
         // Navigation
@@ -687,6 +693,8 @@
             // Auto-refresh review queue when section is opened
             if (sectionId === 'review-queue') {
                 refreshReviewQueue();
+            } else if (sectionId === 'collector') {
+                loadSources();
             }
         }
 
@@ -826,6 +834,38 @@
 
         async function stopCollection() {
             logMessage('task-log', 'warning', 'Stop function not implemented yet');
+        }
+
+        async function loadSources() {
+            try {
+                const sources = await apiCall('/sources');
+                const container = document.getElementById('sources-list');
+                container.innerHTML = '';
+                sources.forEach((src, idx) => {
+                    const div = document.createElement('div');
+                    div.className = 'form-group';
+                    div.innerHTML = `
+                        <label>${src.name}</label>
+                        <input type="number" id="limit-${idx}" value="${src.limit || 50}" min="1" style="width:80px;">
+                        <button class="btn btn-small" onclick="updateSourceLimit('${src.url}', document.getElementById('limit-${idx}').value)">Save</button>
+                    `;
+                    container.appendChild(div);
+                });
+            } catch (error) {
+                logMessage('task-log', 'error', `Failed to load sources: ${error.message}`);
+            }
+        }
+
+        async function updateSourceLimit(url, limit) {
+            try {
+                await apiCall('/sources/update', {
+                    method: 'POST',
+                    body: JSON.stringify({ url, limit: parseInt(limit) })
+                });
+                logMessage('task-log', 'success', `Updated limit for ${url}`);
+            } catch (error) {
+                logMessage('task-log', 'error', `Failed to update source: ${error.message}`);
+            }
         }
 
         // Analysis functions


### PR DESCRIPTION
## Summary
- add optional `limit` field to sources in `config.json`
- allow setting per-source limits in default config
- respect `limit` field in content collector
- create `/api/sources/update` endpoint
- expose source limits on dashboard with update controls

## Testing
- `python -m py_compile Night_Watcher.py collector.py night_watcher_web.py`

------
https://chatgpt.com/codex/tasks/task_e_6842fc44029883328b8470cb95b35c88