### PR TITLE
Improve dashboard configuration controls

### DIFF
--- a/config.json
+++ b/config.json
@@ -111,8 +111,8 @@
     "delay_between_requests": 2.0
   },
   "llm_provider": {
-    "type": "anthropic",
-    "model": "claude-3-haiku-20240307"
+    "type": "lm_studio",
+    "model": ""
   },
   "analysis": {
     "max_articles": 20

--- a/night_watcher_dashboard.html
+++ b/night_watcher_dashboard.html
@@ -185,6 +185,11 @@
             box-shadow: 0 4px 15px rgba(49, 130, 206, 0.4);
         }
 
+        .btn:active {
+            transform: scale(0.97);
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2) inset;
+        }
+
         .btn-success {
             background: linear-gradient(135deg, #38a169 0%, #2f855a 100%);
             color: white;
@@ -456,6 +461,14 @@
                         <button class="btn btn-primary" onclick="startCollection()">Start Collection</button>
                         <button class="btn btn-danger" onclick="stopCollection()">Stop Collection</button>
                         <div class="form-group" style="margin-top:1rem;">
+                            <label>LLM Provider</label>
+                            <select id="llm-provider">
+                                <option value="lm_studio">LM Studio</option>
+                                <option value="anthropic">Anthropic</option>
+                            </select>
+                            <button class="btn btn-small" onclick="saveLLMProvider()">Set</button>
+                        </div>
+                        <div class="form-group" style="margin-top:1rem;">
                             <label>Anthropic API Key</label>
                             <input type="text" id="anthropic-key" placeholder="sk-...">
                             <button class="btn btn-small" onclick="saveAPIKey()">Save</button>
@@ -476,6 +489,11 @@
 
                     <div class="control-panel">
                         <h3>Source Limits</h3>
+                        <div class="form-group">
+                            <label>Articles per Source</label>
+                            <input type="number" id="global-limit" value="50" min="1" style="width:80px;">
+                            <button class="btn btn-small" onclick="setGlobalLimit()">Apply</button>
+                        </div>
                         <div id="sources-list"></div>
                     </div>
                 </div>
@@ -686,6 +704,7 @@
             refreshReviewQueue();
             loadSources();
             loadLLMModels();
+            loadLLMProvider();
         });
 
         // Navigation
@@ -778,7 +797,7 @@
         }
 
         function startStatusPolling() {
-            statusInterval = setInterval(refreshStatus, 5000);
+            statusInterval = setInterval(refreshStatus, 2000);
         }
 
         // Task monitoring
@@ -793,16 +812,27 @@
                 // Update logs
                 if (taskStatus.messages && taskStatus.messages.length > 0) {
                     const logContainer = document.getElementById('task-log');
+                    const analyzerContainer = document.getElementById('analyzer-log');
                     logContainer.innerHTML = '';
-                    
+                    if (taskStatus.task === 'analysis') {
+                        analyzerContainer.innerHTML = '';
+                    }
+
                     taskStatus.messages.forEach(msg => {
                         const entry = document.createElement('div');
                         entry.className = `log-entry ${msg.level}`;
                         entry.textContent = `[${msg.time}] ${msg.message}`;
                         logContainer.appendChild(entry);
+                        if (taskStatus.task === 'analysis') {
+                            const clone = entry.cloneNode(true);
+                            analyzerContainer.appendChild(clone);
+                        }
                     });
-                    
+
                     logContainer.scrollTop = logContainer.scrollHeight;
+                    if (taskStatus.task === 'analysis') {
+                        analyzerContainer.scrollTop = analyzerContainer.scrollHeight;
+                    }
                 }
                 
                 // Stop polling if task is done
@@ -866,6 +896,30 @@
             }
         }
 
+        async function loadLLMProvider() {
+            try {
+                const cfg = await apiCall('/config');
+                const provider = cfg.llm_provider?.type || 'lm_studio';
+                document.getElementById('llm-provider').value = provider;
+            } catch (error) {
+                logMessage('task-log', 'error', `Failed to load provider: ${error.message}`);
+            }
+        }
+
+        async function saveLLMProvider() {
+            const provider = document.getElementById('llm-provider').value;
+            try {
+                await apiCall('/config', {
+                    method: 'POST',
+                    body: JSON.stringify({ llm_provider: { type: provider } })
+                });
+                logMessage('task-log', 'success', `Provider set to ${provider}`);
+                loadLLMModels();
+            } catch (error) {
+                logMessage('task-log', 'error', `Failed to set provider: ${error.message}`);
+            }
+        }
+
         async function loadLLMModels() {
             try {
                 const models = await apiCall('/llm-models');
@@ -914,8 +968,25 @@
                     `;
                     container.appendChild(div);
                 });
+                const cfg = await apiCall('/config');
+                document.getElementById('global-limit').value = cfg.content_collection?.article_limit || 50;
             } catch (error) {
                 logMessage('task-log', 'error', `Failed to load sources: ${error.message}`);
+            }
+        }
+
+        async function setGlobalLimit() {
+            const limit = document.getElementById('global-limit').value;
+            if (!limit) return;
+            try {
+                await apiCall('/sources/set-limit', {
+                    method: 'POST',
+                    body: JSON.stringify({ limit: parseInt(limit) })
+                });
+                logMessage('task-log', 'success', `Set article limit to ${limit}`);
+                loadSources();
+            } catch (error) {
+                logMessage('task-log', 'error', `Failed to set limit: ${error.message}`);
             }
         }
 

--- a/night_watcher_web.py
+++ b/night_watcher_web.py
@@ -149,9 +149,9 @@ def api_status():
     try:
         init_night_watcher()
         
-        # Cache status for 30 seconds
+        # Cache status for 5 seconds
         now = datetime.now()
-        if stats_cache["last_update"] and (now - stats_cache["last_update"]).seconds < 30:
+        if stats_cache["last_update"] and (now - stats_cache["last_update"]).seconds < 5:
             # But always update certain fields
             status = stats_cache["data"].copy()
         else:
@@ -655,6 +655,34 @@ def api_update_source():
             json.dump(night_watcher.config, f, indent=2)
 
         add_log_message("success", f"Updated source limit for {url}")
+        return jsonify({"status": "updated"})
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
+@app.route('/api/sources/set-limit', methods=['POST'])
+def api_set_source_limit():
+    """Set article limit for all sources."""
+    try:
+        init_night_watcher()
+        data = request.json
+        limit = data.get("limit")
+
+        if limit is None:
+            return jsonify({"error": "limit required"}), 400
+
+        sources = night_watcher.config.get("content_collection", {}).get("sources", [])
+        for src in sources:
+            src["limit"] = int(limit)
+
+        night_watcher.collector.sources = sources
+        night_watcher.config["content_collection"]["article_limit"] = int(limit)
+
+        with open(night_watcher.config_path, 'w', encoding='utf-8') as f:
+            json.dump(night_watcher.config, f, indent=2)
+
+        add_log_message("success", f"Set article limit for all sources: {limit}")
         return jsonify({"status": "updated"})
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- add button active effect and dynamic provider selection
- reduce status polling interval
- show logs in analyzer panel during analysis
- allow setting article limit for all sources
- add LM Studio as default LLM provider

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68476a2842a0833289b89150e389a0c2