### PR TITLE
Improve analysis UI with A/B template testing

### DIFF
--- a/night_watcher_dashboard.html
+++ b/night_watcher_dashboard.html
@@ -402,15 +402,9 @@
             <div class="nav-item active" onclick="showSection('collector')">
                 📡 Content Collector
             </div>
-            <div class="nav-item" onclick="showSection('analyzer')">
-                🔍 Content Analyzer
-            </div>
-            <div class="nav-item" onclick="showSection('review-queue')">
-                👁️ Review Queue
+            <div class="nav-item" onclick="showSection('analysis')">
+                🔍 Analysis
                 <span class="nav-badge" id="review-count" style="display: none;">0</span>
-            </div>
-            <div class="nav-item" onclick="showSection('templates')">
-                📋 Analysis Templates
             </div>
             <div class="nav-item" onclick="showSection('knowledge-graph')">
                 🕸️ Knowledge Graph
@@ -512,9 +506,9 @@
                 </div>
             </div>
 
-            <!-- Content Analyzer Section -->
-            <div id="analyzer" class="section">
-                <h2>Content Analyzer</h2>
+            <!-- Analysis Section -->
+            <div id="analysis" class="section">
+                <h2>Analysis</h2>
                 
                 <div class="status-grid">
                     <div class="status-card">
@@ -544,6 +538,9 @@
                             <label>Max Articles to Analyze</label>
                             <input type="number" id="max-analyze" value="20" min="1" max="100">
                         </div>
+                        <div class="form-group">
+                            <label><input type="checkbox" id="ab-split"> A/B Split Templates</label>
+                        </div>
                         <button class="btn btn-primary" onclick="startAnalysis()">Start Analysis</button>
                     </div>
                 </div>
@@ -551,11 +548,9 @@
                 <div class="log-container" id="analyzer-log">
                     <div class="log-entry info">[INFO] Content Analyzer ready</div>
                 </div>
-            </div>
 
-            <!-- Review Queue Section -->
-            <div id="review-queue" class="section">
-                <h2>Review Queue</h2>
+            <h3 style="margin-top:2rem;">Review Queue</h3>
+            <div id="review-queue-section">
                 
                 <div class="status-grid">
                     <div class="status-card">
@@ -587,9 +582,8 @@
                 </div>
             </div>
 
-            <!-- Templates Section -->
-            <div id="templates" class="section">
-                <h2>Analysis Templates</h2>
+            <h3 style="margin-top:2rem;">Analysis Templates</h3>
+            <div id="templates-section">
                 
                 <div class="control-grid">
                     <div class="control-panel">
@@ -614,6 +608,7 @@
                     <div class="log-entry info">[INFO] Templates ready</div>
                 </div>
             </div>
+            <!-- end analysis section -->
 
             <!-- Knowledge Graph Section -->
             <div id="knowledge-graph" class="section">
@@ -755,9 +750,10 @@
             document.getElementById(sectionId).classList.add('active');
             event.target.classList.add('active');
 
-            // Auto-refresh review queue when section is opened
-            if (sectionId === 'review-queue') {
+            // Auto-refresh sections when opened
+            if (sectionId === 'analysis') {
                 refreshReviewQueue();
+                loadTemplates();
             } else if (sectionId === 'collector') {
                 loadSources();
             }
@@ -1079,17 +1075,20 @@
             const maxArticles = parseInt(document.getElementById('max-analyze').value);
             const selector = document.getElementById('analysis-templates');
             const templates = Array.from(selector.selectedOptions).map(o => o.value);
+            const abSplit = document.getElementById('ab-split').checked;
 
             try {
                 await apiCall('/analyze', {
                     method: 'POST',
                     body: JSON.stringify({
                         max_articles: maxArticles,
-                        templates: templates
+                        templates: templates,
+                        ab_split: abSplit
                     })
                 });
 
-                logMessage('analyzer-log', 'info', `Analysis started with templates: ${templates.join(', ')}`);
+                const mode = abSplit && templates.length > 1 ? 'A/B' : 'standard';
+                logMessage('analyzer-log', 'info', `Analysis started (${mode}) with templates: ${templates.join(', ')}`);
                 startTaskPolling();
                 
             } catch (error) {


### PR DESCRIPTION
## Summary
- merge Analyzer, Review Queue and Templates tabs into a single **Analysis** tab
- add checkbox to enable A/B split testing of analysis templates
- support `ab_split` option in API and NightWatcher.analyze

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a55ab7c083328d0879ca0d5c8864