### PR TITLE
Implement signed artifact export & decentralized client

### DIFF
--- a/Night_Watcher.py
+++ b/Night_Watcher.py
@@ -362,6 +362,11 @@ def main():
     parser.add_argument("--sync-vectors", action="store_true", help="Sync vectors")
     parser.add_argument("--full", action="store_true", help="Run full pipeline")
     parser.add_argument("--status", action="store_true", help="Show status")
+    parser.add_argument("--export-signed", help="Export signed release artifact")
+    parser.add_argument("--version", help="Version (v001, v002, etc)")
+    parser.add_argument("--private-key", help="Private key file for signing")
+    parser.add_argument("--previous-artifact", help="Previous artifact for chain")
+    parser.add_argument("--bundle-files", nargs="+", help="Extra files to include")
     
     # Options
     parser.add_argument("--mode", choices=["auto", "first_run", "incremental", "full"],
@@ -405,7 +410,17 @@ def main():
         elif args.sync_vectors:
             result = nw.sync_vectors()
             print(f"✓ Synced {result['nodes_added']} vectors")
-        
+
+        elif args.export_signed:
+            from export_signed_artifact import export_signed_artifact
+            export_signed_artifact(
+                output_path=args.export_signed,
+                version=args.version,
+                private_key_path=args.private_key,
+                previous_artifact_path=args.previous_artifact,
+                bundled_files=args.bundle_files,
+            )
+
         elif args.full:
             print("Running full pipeline...")
             

--- a/export_signed_artifact.py
+++ b/export_signed_artifact.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Export signed, versioned Night_watcher artifacts."""
+
+from __future__ import annotations
+
+import os
+import json
+import tarfile
+import hashlib
+import tempfile
+import shutil
+from datetime import datetime
+from typing import List, Optional
+import base64
+import time
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+
+from knowledge_graph import KnowledgeGraph
+from vector_store import VectorStore
+from document_repository import DocumentRepository
+
+
+def file_hash(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def build_manifest(directory: str) -> dict:
+    manifest = {
+        "generated_at": datetime.now().isoformat(),
+        "files": {},
+    }
+    for root, _, files in os.walk(directory):
+        for file in files:
+            path = os.path.join(root, file)
+            rel = os.path.relpath(path, directory)
+            manifest["files"][rel] = f"sha256:{file_hash(path)}"
+    return manifest
+
+
+def _bencode(value) -> bytes:
+    """Very small bencode implementation for torrent generation."""
+    if isinstance(value, int):
+        return f"i{value}e".encode()
+    if isinstance(value, bytes):
+        return str(len(value)).encode() + b":" + value
+    if isinstance(value, str):
+        b = value.encode()
+        return str(len(b)).encode() + b":" + b
+    if isinstance(value, list):
+        return b"l" + b"".join(_bencode(x) for x in value) + b"e"
+    if isinstance(value, dict):
+        items = sorted(value.items())
+        out = b"d"
+        for k, v in items:
+            out += _bencode(str(k)) + _bencode(v)
+        out += b"e"
+        return out
+    raise TypeError(f"Unsupported type: {type(value)}")
+
+
+def _generate_torrent(file_path: str, torrent_path: str):
+    piece_length = 262144  # 256 KiB
+    pieces = []
+    with open(file_path, "rb") as f:
+        while True:
+            chunk = f.read(piece_length)
+            if not chunk:
+                break
+            pieces.append(hashlib.sha1(chunk).digest())
+    info = {
+        "name": os.path.basename(file_path),
+        "piece length": piece_length,
+        "length": os.path.getsize(file_path),
+        "pieces": b"".join(pieces),
+    }
+    torrent = {
+        "announce": "https://example.com/announce",
+        "creation date": int(time.time()),
+        "created by": "NightWatcher",
+        "info": info,
+    }
+    with open(torrent_path, "wb") as f:
+        f.write(_bencode(torrent))
+
+
+def export_signed_artifact(
+    output_path: str,
+    version: str,
+    private_key_path: str,
+    kg_dir: str = "data/knowledge_graph",
+    vector_dir: str = "data/vector_store",
+    documents_dir: str = "data/documents",
+    previous_artifact_path: Optional[str] = None,
+    bundled_files: Optional[List[str]] = None,
+):
+    """Export signed, versioned artifact with provenance chain."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Export intelligence data
+        kg = KnowledgeGraph(graph_file=os.path.join(kg_dir, "graph.json"), taxonomy_file="KG_Taxonomy.csv")
+        kg.export_graph(os.path.join(tmpdir, "intelligence", "graph"))
+        VectorStore(base_dir=vector_dir).export_vector_store(os.path.join(tmpdir, "intelligence", "vector_store"))
+        DocumentRepository(base_dir=documents_dir, dev_mode=True).export_repository(os.path.join(tmpdir, "intelligence", "documents"))
+
+        # Include bundled files
+        bundle_dir = os.path.join(tmpdir, "bundled_files")
+        os.makedirs(bundle_dir, exist_ok=True)
+        bundled = []
+        for f in bundled_files or []:
+            if os.path.exists(f):
+                shutil.copy2(f, os.path.join(bundle_dir, os.path.basename(f)))
+                bundled.append(os.path.basename(f))
+
+        # Build manifest
+        manifest = build_manifest(tmpdir)
+        with open(os.path.join(tmpdir, "manifest.json"), "w", encoding="utf-8") as f:
+            json.dump(manifest, f, indent=2)
+
+        # Build provenance
+        prev_hash = file_hash(previous_artifact_path) if previous_artifact_path else None
+        prev_version = None
+        if previous_artifact_path:
+            # assume filename includes version like night_watcher_v001.tar.gz
+            base = os.path.basename(previous_artifact_path)
+            if "_v" in base:
+                prev_version = base.split("_v")[-1].split(".")[0]
+        provenance = {
+            "version": version,
+            "previous_version": prev_version,
+            "previous_hash": f"sha256:{prev_hash}" if prev_hash else None,
+            "export_time": datetime.utcnow().isoformat() + "Z",
+            "genesis": previous_artifact_path is None,
+            "bundled_files": bundled,
+        }
+        with open(os.path.join(tmpdir, "provenance.json"), "w", encoding="utf-8") as f:
+            json.dump(provenance, f, indent=2)
+
+        # Sign
+        data = json.dumps(manifest, sort_keys=True).encode() + json.dumps(provenance, sort_keys=True).encode()
+        digest = hashlib.sha256(data).hexdigest()
+        private_key = serialization.load_pem_private_key(open(private_key_path, "rb").read(), password=None)
+        signature_bytes = private_key.sign(
+            data,
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+            hashes.SHA256(),
+        )
+        signature = {
+            "algorithm": "RSA-PSS-SHA256",
+            "signature": base64.b64encode(signature_bytes).decode(),
+            "signed_data_hash": f"sha256:{digest}",
+        }
+        with open(os.path.join(tmpdir, "signature.json"), "w", encoding="utf-8") as f:
+            json.dump(signature, f, indent=2)
+
+        public_key = private_key.public_key()
+        pub_bytes = public_key.public_bytes(serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo)
+        with open(os.path.join(tmpdir, "public_key.pem"), "wb") as f:
+            f.write(pub_bytes)
+
+        # Package
+        with tarfile.open(output_path, "w:gz") as tar:
+            tar.add(tmpdir, arcname=".")
+
+    # Generate torrent
+    torrent_name = f"night_watcher_{version}.torrent"
+    _generate_torrent(output_path, torrent_name)
+    print(f"Exported signed artifact to {output_path} and {torrent_name}")
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Export signed Night_watcher artifact")
+    parser.add_argument("output", help="Output archive path")
+    parser.add_argument("--version", required=True, help="Version string")
+    parser.add_argument("--private-key", required=True, help="Private key path")
+    parser.add_argument("--previous-artifact", help="Previous artifact")
+    parser.add_argument("--bundle-files", nargs="+", help="Extra files to bundle")
+    args = parser.parse_args()
+
+    export_signed_artifact(
+        args.output,
+        version=args.version,
+        private_key_path=args.private_key,
+        previous_artifact_path=args.previous_artifact,
+        bundled_files=args.bundle_files,
+    )

--- a/install_client.py
+++ b/install_client.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Installer for Night_watcher client from genesis artifact."""
+
+from __future__ import annotations
+
+import os
+import json
+import tarfile
+import tempfile
+import hashlib
+import shutil
+from typing import Optional
+
+
+def file_hash(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def install_genesis_client(artifact_path: str, install_dir: str = "nw_client"):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with tarfile.open(artifact_path, "r:gz") as tar:
+            tar.extractall(tmpdir)
+        prov_path = os.path.join(tmpdir, "provenance.json")
+        if not os.path.exists(prov_path):
+            raise RuntimeError("provenance.json missing")
+        provenance = json.load(open(prov_path))
+        if not provenance.get("genesis"):
+            raise RuntimeError("Artifact is not genesis")
+
+        # Copy client module
+        client_src = os.path.join(tmpdir, "client_module")
+        if not os.path.exists(client_src):
+            raise RuntimeError("client_module missing")
+        os.makedirs(install_dir, exist_ok=True)
+        for name in os.listdir(client_src):
+            src = os.path.join(client_src, name)
+            dst = os.path.join(install_dir, name)
+            if os.path.isdir(src):
+                if os.path.exists(dst):
+                    continue
+                os.makedirs(dst, exist_ok=True)
+                for fname in os.listdir(src):
+                    shutil.copy2(os.path.join(src, fname), os.path.join(dst, fname))
+            else:
+                shutil.copy2(src, dst)
+
+        # Save public key
+        shutil.copy2(os.path.join(tmpdir, "public_key.pem"), os.path.join(install_dir, "public_key.pem"))
+
+        # Initialize state
+        state = {
+            "version": provenance["version"],
+            "hash": f"sha256:{file_hash(artifact_path)}",
+        }
+        json.dump(state, open(os.path.join(install_dir, "current.json"), "w"))
+        print(f"Installed Night_watcher client version {provenance['version']}")
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Install genesis Night_watcher client")
+    parser.add_argument("artifact", help="Path to genesis artifact")
+    parser.add_argument("--install-dir", default="nw_client", help="Installation directory")
+    args = parser.parse_args()
+    install_genesis_client(args.artifact, args.install_dir)

--- a/nw_client.py
+++ b/nw_client.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Night_watcher Intelligence Client - Decentralized Version."""
+
+from __future__ import annotations
+
+import os
+import json
+import tarfile
+import tempfile
+import hashlib
+import base64
+from typing import Tuple, Optional
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+
+
+class SignedArtifactVerifier:
+    """Handles verification of signed Night_watcher artifacts."""
+
+    def verify_artifact(self, archive_path: str) -> Tuple[bool, str, dict]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with tarfile.open(archive_path, "r:gz") as tar:
+                tar.extractall(tmpdir)
+            try:
+                manifest = json.load(open(os.path.join(tmpdir, "manifest.json")))
+                provenance = json.load(open(os.path.join(tmpdir, "provenance.json")))
+                signature = json.load(open(os.path.join(tmpdir, "signature.json")))
+                pub_key_bytes = open(os.path.join(tmpdir, "public_key.pem"), "rb").read()
+            except Exception as e:
+                return False, f"missing files: {e}", {}
+
+            # verify hashes
+            for rel, expected in manifest.get("files", {}).items():
+                fpath = os.path.join(tmpdir, rel)
+                if not os.path.exists(fpath):
+                    return False, f"missing {rel}", {}
+                h = hashlib.sha256()
+                with open(fpath, "rb") as fh:
+                    for chunk in iter(lambda: fh.read(8192), b""):
+                        h.update(chunk)
+                if f"sha256:{h.hexdigest()}" != expected:
+                    return False, f"hash mismatch for {rel}", {}
+
+            data = json.dumps(manifest, sort_keys=True).encode() + json.dumps(provenance, sort_keys=True).encode()
+            digest = hashlib.sha256(data).hexdigest()
+            if signature.get("signed_data_hash") != f"sha256:{digest}":
+                return False, "signed data hash mismatch", {}
+
+            pubkey = serialization.load_pem_public_key(pub_key_bytes)
+            try:
+                pubkey.verify(
+                    base64.b64decode(signature.get("signature")),
+                    data,
+                    padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+                    hashes.SHA256(),
+                )
+            except Exception:
+                return False, "signature verification failed", {}
+
+            return True, "ok", provenance
+
+
+class ProvenanceChain:
+    """Manages version chain and validates updates."""
+
+    def __init__(self, data_dir: str):
+        self.data_dir = data_dir
+        os.makedirs(self.data_dir, exist_ok=True)
+        self.state_file = os.path.join(self.data_dir, "current.json")
+        self.current_version = self._load_current_version()
+        self.current_hash = self._load_current_hash()
+
+    def _load_current_version(self) -> Optional[str]:
+        if os.path.exists(self.state_file):
+            data = json.load(open(self.state_file))
+            return data.get("version")
+        return None
+
+    def _load_current_hash(self) -> Optional[str]:
+        if os.path.exists(self.state_file):
+            data = json.load(open(self.state_file))
+            return data.get("hash")
+        return None
+
+    def _write_state(self, version: str, hash_: str):
+        json.dump({"version": version, "hash": hash_}, open(self.state_file, "w"))
+        self.current_version = version
+        self.current_hash = hash_
+
+    def validate_update(self, new_provenance: dict) -> bool:
+        if self.current_version is None:
+            return new_provenance.get("genesis", False)
+        if new_provenance.get("previous_version") != self.current_version:
+            return False
+        if new_provenance.get("previous_hash") != self.current_hash:
+            return False
+        new_version = new_provenance.get("version")
+        try:
+            curr_num = int(self.current_version.lstrip("v"))
+            new_num = int(new_version.lstrip("v"))
+        except Exception:
+            return False
+        return new_num == curr_num + 1
+
+
+class UpdateDiscovery:
+    """Discovers new versions via torrent naming."""
+
+    def check_for_updates(self, current_version: str) -> Optional[str]:
+        if not current_version:
+            return None
+        try:
+            curr_num = int(current_version.lstrip("v"))
+        except Exception:
+            return None
+        next_ver = f"v{curr_num+1:03d}"
+        fname = f"night_watcher_{next_ver}.torrent"
+        if os.path.exists(fname):
+            return os.path.abspath(fname)
+        return None
+
+
+class NightWatcherClient:
+    """Main client for handling signed artifacts."""
+
+    def __init__(self, data_dir: str = "nw_client_data"):
+        self.data_dir = data_dir
+        os.makedirs(self.data_dir, exist_ok=True)
+        self.verifier = SignedArtifactVerifier()
+        self.provenance = ProvenanceChain(self.data_dir)
+        self.discovery = UpdateDiscovery()
+
+    def install_artifact(self, archive_path: str) -> bool:
+        ok, reason, provenance = self.verifier.verify_artifact(archive_path)
+        if not ok:
+            print(f"Verification failed: {reason}")
+            return False
+        if not self.provenance.validate_update(provenance):
+            print("Provenance chain validation failed")
+            return False
+        # Extract
+        with tarfile.open(archive_path, "r:gz") as tar:
+            tar.extractall(self.data_dir)
+        hash_ = f"sha256:{file_hash(archive_path)}"
+        self.provenance._write_state(provenance["version"], hash_)
+        return True
+
+    def check_for_updates(self) -> Optional[str]:
+        return self.discovery.check_for_updates(self.provenance.current_version)
+
+    def auto_update_check(self):
+        info = self.check_for_updates()
+        if info:
+            print(f"Update available: {info}")
+
+
+def file_hash(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Night_watcher Client")
+    sub = parser.add_subparsers(dest="cmd")
+
+    inst = sub.add_parser("install", help="Install artifact")
+    inst.add_argument("archive")
+
+    sub.add_parser("status", help="Show status")
+    sub.add_parser("check-updates", help="Check for updates")
+
+    args = parser.parse_args()
+    client = NightWatcherClient()
+
+    if args.cmd == "install":
+        if client.install_artifact(args.archive):
+            print("Installation successful")
+    elif args.cmd == "status":
+        print(json.dumps({"version": client.provenance.current_version}, indent=2))
+    elif args.cmd == "check-updates":
+        info = client.check_for_updates()
+        print(info or "No updates found")
+    else:
+        parser.print_help()


### PR DESCRIPTION
## Summary
- export signed Night Watcher artifacts with private key and provenance chain
- embed public key and build torrent files
- provide decentralized client module for verifying and installing updates
- add helper to install client from genesis artifact
- expose `--export-signed` workflow in `Night_Watcher.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ef3bba7c8332b8c920e4bca9a515