### PR TITLE
Simplify template review workflow

### DIFF
--- a/event_analysis.json
+++ b/event_analysis.json
@@ -1,46 +1,46 @@
 {
-  "name": "events_analysis_v2",
-  "description": "Event-focused analysis that works with Night_watcher's pipeline",
-  "status": "REJECTED",
-  "version": "2.0",
-  "created": "2025-01-01",
-  "rounds": [
-    {
-      "name": "fact_extraction",
-      "prompt": "Extract events and temporal facts from this article.\n\nFocus on:\n- Specific events that occurred or are planned\n- Dates and temporal sequences\n- Causal relationships between events\n- Key actors and their actions\n\nYour response MUST be a valid JSON object:\n{{\n  \"publication_date\": \"{publication_date}\",\n  \"facts\": [\n    \"On [date], [actor] did [action]\",\n    \"This event caused/enabled/prevented [other event]\",\n    \"The sequence was: [event1] \u2192 [event2] \u2192 [event3]\"\n  ],\n  \"events\": [\n    {{\n      \"name\": \"Event name\",\n      \"date\": \"YYYY-MM-DD or N/A\",\n      \"description\": \"What happened\"\n    }}\n  ],\n  \"direct_quotes\": [\n    \"Quote about an event\",\n    \"Quote about timing or sequence\"\n  ]\n}}\n\nExtract ALL events and temporal relationships. Use \"N/A\" for unknown dates.\n\nCONTENT:\n{article_content}",
-      "max_tokens": 2500
-    },
-    {
-      "name": "article_analysis",
-      "prompt": "Analyze the temporal and causal patterns in these events.\n\nFacts extracted:\n{facts}\n\nProvide analysis of:\n\n1. TEMPORAL PATTERNS\n   - Event clustering (multiple events in short time)\n   - Acceleration/deceleration of activity\n   - Strategic timing choices\n   - Deadline-driven events\n\n2. CAUSAL CHAINS\n   - Which events directly caused others?\n   - What feedback loops exist?\n   - Are there cascade effects?\n   - What are the trigger events?\n\n3. DEMOCRATIC IMPACT\n   - How do these events affect democratic norms?\n   - Is there a pattern of escalation?\n   - What institutions are being tested?\n   - Rate the urgency (1-10)\n\n4. PREDICTIVE INDICATORS\n   - What events are likely to follow?\n   - What are the warning signs?\n   - Where are intervention points?\n\n5. MANIPULATION & FRAMING\n   - How are events being framed?\n   - What narratives justify these actions?\n   - Is timing being used strategically?\n\nProvide thorough analysis with specific examples.",
-      "max_tokens": 2500
-    },
-    {
-      "name": "node_extraction",
-      "prompt": "Extract nodes for the knowledge graph, focusing on events and temporal entities.\n\nBased on the facts:\n{facts}\n\nExtract nodes for:\n1. Events (node_type: \"event\") - specific occurrences with dates\n2. Actors (node_type: \"actor\") - people taking actions  \n3. Institutions (node_type: \"institution\") - organizations involved\n4. Temporal patterns (node_type: \"temporal_pattern\") - recurring sequences\n5. Causal chains (node_type: \"causal_chain\") - linked event sequences\n\nYour ENTIRE response must be ONLY a valid JSON array:\n[\n  {{\n    \"node_type\": \"event\",\n    \"name\": \"National Guard Deployment to LA\",\n    \"attributes\": {{\n      \"date\": \"2025-06-10\",\n      \"event_type\": \"military_deployment\",\n      \"urgency\": \"high\",\n      \"reversibility\": \"difficult\",\n      \"democratic_impact\": 8\n    }},\n    \"timestamp\": \"2025-06-10\",\n    \"source_sentence\": \"Trump deployed National Guard to Los Angeles\"\n  }},\n  {{\n    \"node_type\": \"temporal_pattern\",\n    \"name\": \"Crisis-Response Escalation\",\n    \"attributes\": {{\n      \"pattern_type\": \"escalation\",\n      \"frequency\": \"accelerating\",\n      \"risk_level\": \"high\"\n    }},\n    \"timestamp\": \"N/A\",\n    \"source_sentence\": \"Each response has been more severe than the last\"\n  }}\n]\n\nInclude ALL significant events, actors, patterns. Focus on temporal and causal aspects.",
-      "max_tokens": 3000
-    },
-    {
-      "name": "node_deduplication",
-      "prompt": "Deduplicate nodes and assign IDs.\n\nNodes:\n{nodes}\n\nPublication date:\n{publication_date}\n\nMerge duplicate nodes (same type + similar name) and assign sequential IDs.\n\nYour ENTIRE response must be ONLY a valid JSON array:\n[\n  {{\n    \"id\": 1,\n    \"node_type\": \"event\",\n    \"name\": \"National Guard Deployment to LA\",\n    \"attributes\": {{\n      \"date\": \"2025-06-10\",\n      \"event_type\": \"military_deployment\",\n      \"urgency\": \"high\",\n      \"reversibility\": \"difficult\",\n      \"democratic_impact\": 8\n    }},\n    \"timestamp\": \"2025-06-10\"\n  }}\n]\n\nStart with [ and end with ]. Assign IDs starting from 1.",
-      "max_tokens": 2500
-    },
-    {
-      "name": "edge_extraction",
-      "prompt": "Extract temporal and causal relationships between nodes.\n\nNodes (with IDs):\n{nodes}\n\nOriginal facts for context:\n{facts}\n\nExtract edges focusing on:\n- Temporal relations: precedes, follows, coincides_with\n- Causal relations: causes, enables, prevents, triggers, accelerates\n- Response relations: responds_to, escalates, retaliates\n- Pattern relations: part_of_pattern, exemplifies, breaks_pattern\n\nYour ENTIRE response must be ONLY a valid JSON array:\n[\n  {{\n    \"source_id\": 1,\n    \"relation\": \"triggers\",\n    \"target_id\": 3,\n    \"timestamp\": \"2025-06-10\",\n    \"evidence_quote\": \"The deployment immediately triggered protests\"\n  }},\n  {{\n    \"source_id\": 2,\n    \"relation\": \"part_of_pattern\",\n    \"target_id\": 5,\n    \"timestamp\": \"2025-06-10\",\n    \"evidence_quote\": \"This follows the pattern of escalating responses\"\n  }}\n]\n\nMap node names to IDs based on the nodes array order. Focus on temporal and causal relationships.",
-      "max_tokens": 3000
-    },
-    {
-      "name": "edge_enrichment",
-      "prompt": "Enrich edges with impact assessment.\n\nEdges:\n{edges}\n\nFor each edge, add:\n- severity: 0.0-1.0 (impact on democracy)\n- is_decayable: true if effect fades over time\n- reasoning: why this relationship matters\n\nConsider:\n- Temporal edges (precedes/follows) - usually low severity, decayable\n- Causal edges (causes/triggers) - higher severity based on outcome\n- Escalation edges - high severity, not decayable\n- Pattern edges - severity based on pattern danger\n\nYour ENTIRE response must be ONLY a valid JSON array with ALL original fields plus new ones:\n[\n  {{\n    \"source_id\": 1,\n    \"relation\": \"triggers\",\n    \"target_id\": 3,\n    \"timestamp\": \"2025-06-10\",\n    \"evidence_quote\": \"The deployment immediately triggered protests\",\n    \"severity\": 0.7,\n    \"is_decayable\": false,\n    \"reasoning\": \"Military deployment triggering protests shows democratic tension\"\n  }}\n]\n\nIf input is [], output [].",
-      "max_tokens": 3000
-    },
-    {
-      "name": "package_ingestion",
-      "prompt": "Create final knowledge graph package.\n\nNodes:\n{nodes}\n\nEdges:\n{edges}\n\nCombine the nodes and edges into a single JSON object with this exact structure:\n{{\n  \"nodes\": [...],\n  \"edges\": [...]\n}}\n\nYour ENTIRE response must be ONLY this JSON object. Copy the nodes array and edges array exactly as provided above.",
-      "max_tokens": 3000
-    }
-  ],
-  "rejected_at": "2025-06-12T10:31:25.581443",
-  "rejected_by": "dashboard_user"
+    "name": "events_analysis_v2",
+    "description": "Event-focused analysis that works with Night_watcher's pipeline",
+    "status": "TESTING",
+    "version": "2.0",
+    "created": "2025-01-01",
+    "rounds": [
+        {
+            "name": "fact_extraction",
+            "prompt": 'Extract events and temporal facts from this article.\n\nFocus on:\n- Specific events that occurred or are planned\n- Dates and temporal sequences\n- Causal relationships between events\n- Key actors and their actions\n\nYour response MUST be a valid JSON object:\n{{\n  "publication_date": "{publication_date}",\n  "facts": [\n    "On [date], [actor] did [action]",\n    "This event caused/enabled/prevented [other event]",\n    "The sequence was: [event1] \u2192 [event2] \u2192 [event3]"\n  ],\n  "events": [\n    {{\n      "name": "Event name",\n      "date": "YYYY-MM-DD or N/A",\n      "description": "What happened"\n    }}\n  ],\n  "direct_quotes": [\n    "Quote about an event",\n    "Quote about timing or sequence"\n  ]\n}}\n\nExtract ALL events and temporal relationships. Use "N/A" for unknown dates.\n\nCONTENT:\n{article_content}',
+            "max_tokens": 2500,
+        },
+        {
+            "name": "article_analysis",
+            "prompt": "Analyze the temporal and causal patterns in these events.\n\nFacts extracted:\n{facts}\n\nProvide analysis of:\n\n1. TEMPORAL PATTERNS\n   - Event clustering (multiple events in short time)\n   - Acceleration/deceleration of activity\n   - Strategic timing choices\n   - Deadline-driven events\n\n2. CAUSAL CHAINS\n   - Which events directly caused others?\n   - What feedback loops exist?\n   - Are there cascade effects?\n   - What are the trigger events?\n\n3. DEMOCRATIC IMPACT\n   - How do these events affect democratic norms?\n   - Is there a pattern of escalation?\n   - What institutions are being tested?\n   - Rate the urgency (1-10)\n\n4. PREDICTIVE INDICATORS\n   - What events are likely to follow?\n   - What are the warning signs?\n   - Where are intervention points?\n\n5. MANIPULATION & FRAMING\n   - How are events being framed?\n   - What narratives justify these actions?\n   - Is timing being used strategically?\n\nProvide thorough analysis with specific examples.",
+            "max_tokens": 2500,
+        },
+        {
+            "name": "node_extraction",
+            "prompt": 'Extract nodes for the knowledge graph, focusing on events and temporal entities.\n\nBased on the facts:\n{facts}\n\nExtract nodes for:\n1. Events (node_type: "event") - specific occurrences with dates\n2. Actors (node_type: "actor") - people taking actions  \n3. Institutions (node_type: "institution") - organizations involved\n4. Temporal patterns (node_type: "temporal_pattern") - recurring sequences\n5. Causal chains (node_type: "causal_chain") - linked event sequences\n\nYour ENTIRE response must be ONLY a valid JSON array:\n[\n  {{\n    "node_type": "event",\n    "name": "National Guard Deployment to LA",\n    "attributes": {{\n      "date": "2025-06-10",\n      "event_type": "military_deployment",\n      "urgency": "high",\n      "reversibility": "difficult",\n      "democratic_impact": 8\n    }},\n    "timestamp": "2025-06-10",\n    "source_sentence": "Trump deployed National Guard to Los Angeles"\n  }},\n  {{\n    "node_type": "temporal_pattern",\n    "name": "Crisis-Response Escalation",\n    "attributes": {{\n      "pattern_type": "escalation",\n      "frequency": "accelerating",\n      "risk_level": "high"\n    }},\n    "timestamp": "N/A",\n    "source_sentence": "Each response has been more severe than the last"\n  }}\n]\n\nInclude ALL significant events, actors, patterns. Focus on temporal and causal aspects.',
+            "max_tokens": 3000,
+        },
+        {
+            "name": "node_deduplication",
+            "prompt": 'Deduplicate nodes and assign IDs.\n\nNodes:\n{nodes}\n\nPublication date:\n{publication_date}\n\nMerge duplicate nodes (same type + similar name) and assign sequential IDs.\n\nYour ENTIRE response must be ONLY a valid JSON array:\n[\n  {{\n    "id": 1,\n    "node_type": "event",\n    "name": "National Guard Deployment to LA",\n    "attributes": {{\n      "date": "2025-06-10",\n      "event_type": "military_deployment",\n      "urgency": "high",\n      "reversibility": "difficult",\n      "democratic_impact": 8\n    }},\n    "timestamp": "2025-06-10"\n  }}\n]\n\nStart with [ and end with ]. Assign IDs starting from 1.',
+            "max_tokens": 2500,
+        },
+        {
+            "name": "edge_extraction",
+            "prompt": 'Extract temporal and causal relationships between nodes.\n\nNodes (with IDs):\n{nodes}\n\nOriginal facts for context:\n{facts}\n\nExtract edges focusing on:\n- Temporal relations: precedes, follows, coincides_with\n- Causal relations: causes, enables, prevents, triggers, accelerates\n- Response relations: responds_to, escalates, retaliates\n- Pattern relations: part_of_pattern, exemplifies, breaks_pattern\n\nYour ENTIRE response must be ONLY a valid JSON array:\n[\n  {{\n    "source_id": 1,\n    "relation": "triggers",\n    "target_id": 3,\n    "timestamp": "2025-06-10",\n    "evidence_quote": "The deployment immediately triggered protests"\n  }},\n  {{\n    "source_id": 2,\n    "relation": "part_of_pattern",\n    "target_id": 5,\n    "timestamp": "2025-06-10",\n    "evidence_quote": "This follows the pattern of escalating responses"\n  }}\n]\n\nMap node names to IDs based on the nodes array order. Focus on temporal and causal relationships.',
+            "max_tokens": 3000,
+        },
+        {
+            "name": "edge_enrichment",
+            "prompt": 'Enrich edges with impact assessment.\n\nEdges:\n{edges}\n\nFor each edge, add:\n- severity: 0.0-1.0 (impact on democracy)\n- is_decayable: true if effect fades over time\n- reasoning: why this relationship matters\n\nConsider:\n- Temporal edges (precedes/follows) - usually low severity, decayable\n- Causal edges (causes/triggers) - higher severity based on outcome\n- Escalation edges - high severity, not decayable\n- Pattern edges - severity based on pattern danger\n\nYour ENTIRE response must be ONLY a valid JSON array with ALL original fields plus new ones:\n[\n  {{\n    "source_id": 1,\n    "relation": "triggers",\n    "target_id": 3,\n    "timestamp": "2025-06-10",\n    "evidence_quote": "The deployment immediately triggered protests",\n    "severity": 0.7,\n    "is_decayable": false,\n    "reasoning": "Military deployment triggering protests shows democratic tension"\n  }}\n]\n\nIf input is [], output [].',
+            "max_tokens": 3000,
+        },
+        {
+            "name": "package_ingestion",
+            "prompt": 'Create final knowledge graph package.\n\nNodes:\n{nodes}\n\nEdges:\n{edges}\n\nCombine the nodes and edges into a single JSON object with this exact structure:\n{{\n  "nodes": [...],\n  "edges": [...]\n}}\n\nYour ENTIRE response must be ONLY this JSON object. Copy the nodes array and edges array exactly as provided above.',
+            "max_tokens": 3000,
+        },
+    ],
+    "rejected_at": "2025-06-12T10:31:25.581443",
+    "rejected_by": "dashboard_user",
 }

--- a/night_watcher_dashboard.html
+++ b/night_watcher_dashboard.html
@@ -616,7 +616,6 @@
                             <input type="number" id="max-analyze" value="20" min="1" max="100">
                         </div>
                         <button class="btn btn-primary" onclick="startAnalysis()">Start Analysis</button>
-                        <button class="btn btn-warning btn-small" onclick="validateSelectedTemplates()">Validate Templates</button>
                     </div>
                 </div>
 
@@ -627,10 +626,7 @@
                 <h3>Review Queue <span style="font-size: 0.8rem; color: #a0aec0;">(Testing Templates Only)</span></h3>
 
                 <div id="template-review-controls" style="margin-bottom: 0.5rem;">
-                    <div id="review-template-list" style="margin-bottom: 0.5rem;"></div>
-                    <button class="btn btn-success btn-small" onclick="approveSelectedTemplates()">Validate Selected Templates</button>
-                    <button class="btn btn-danger btn-small" onclick="rejectSelectedTemplates()">Reject Selected Templates</button>
-
+                    <button class="btn btn-success btn-small" onclick="approveSelectedTemplates()">Approve Selected Templates</button>
                 </div>
                 <div id="review-queue-container" style="margin-bottom: 2rem;">
                     <div class="empty-state">
@@ -1054,7 +1050,6 @@
                 // Update template selectors
                 const selectors = [
                     'analysis-template',
-                    'validate-template-select',
                     'test-template-select'
                 ];
                 
@@ -1132,51 +1127,6 @@
             logMessage('task-log', 'success', 'Templates refreshed');
         }
 
-        async function validateSelectedTemplates() {
-            const selected = document.querySelectorAll('.template-checkbox:checked');
-            if (selected.length === 0) {
-                alert('Please select at least one template');
-                return;
-            }
-
-            for (const cb of selected) {
-                try {
-                    const result = await apiCall('/validate-template', {
-                        method: 'POST',
-                        body: JSON.stringify({ template: cb.value })
-                    });
-                    logMessage('analyzer-log', result.valid ? 'success' : 'warning', `${cb.value}: ${result.valid ? 'Valid' : 'Issues found'}`);
-                } catch (error) {
-                    logMessage('analyzer-log', 'error', `Validation failed for ${cb.value}: ${error.message}`);
-                }
-            }
-        }
-
-        async function validateTemplate() {
-            const template = document.getElementById('validate-template-select').value;
-            const resultsDiv = document.getElementById('validation-results');
-            
-            try {
-                const result = await apiCall('/validate-template', {
-                    method: 'POST',
-                    body: JSON.stringify({ template })
-                });
-                
-                resultsDiv.innerHTML = `
-                    <h4>Validation Results</h4>
-                    <p><strong>Valid:</strong> ${result.valid ? '✅ Yes' : '❌ No'}</p>
-                    ${result.issues.length > 0 ? `
-                        <p><strong>Issues:</strong></p>
-                        <ul>
-                            ${result.issues.map(issue => `<li>${issue}</li>`).join('')}
-                        </ul>
-                    ` : '<p>No issues found!</p>'}
-                `;
-                
-            } catch (error) {
-                resultsDiv.innerHTML = `<p class="error">Validation failed: ${error.message}</p>`;
-            }
-        }
 
         async function testTemplate() {
             const template = document.getElementById('test-template-select').value;
@@ -1316,8 +1266,6 @@
             try {
                 const queue = await apiCall('/review-queue');
                 const container = document.getElementById('review-queue-container');
-                const templateList = document.getElementById('review-template-list');
-                if (templateList) templateList.innerHTML = '';
 
                 if (queue.length === 0) {
                     container.innerHTML = `
@@ -1329,20 +1277,6 @@
                     return;
                 }
 
-                // Populate template checkboxes from queue
-                const templateSet = new Set(queue.map(q => q.template_name));
-                templateSet.forEach(name => {
-                    if (!templateList) return;
-                    const label = document.createElement('label');
-                    label.style.marginRight = '0.5rem';
-                    const cb = document.createElement('input');
-                    cb.type = 'checkbox';
-                    cb.className = 'review-template';
-                    cb.value = name;
-                    label.appendChild(cb);
-                    label.appendChild(document.createTextNode(' ' + name));
-                    templateList.appendChild(label);
-                });
 
                 container.innerHTML = '';
                 queue.forEach((item, index) => {
@@ -1357,10 +1291,10 @@
 
         function createReviewItem(item, index) {
             const div = document.createElement('div');
-            div.className = 'analysis-item';
+            div.className = 'analysis-item expanded';
             div.innerHTML = `
                 <div class="analysis-header">
-                    <input type="checkbox" class="review-select" data-id="${item.id}" style="margin-right:0.5rem;">
+                    <input type="checkbox" class="review-select" data-id="${item.id}" data-template="${item.template_name}" style="margin-right:0.5rem;">
                     <div>
                         <strong>${item.article.title}</strong>
                         <div style="margin-top: 0.5rem;">
@@ -1377,10 +1311,16 @@
                     <p><strong>Manipulation Score:</strong> ${item.manipulation_score || 'N/A'}/10</p>
                     <p><strong>Concern Level:</strong> ${item.concern_level || 'N/A'}</p>
                     <div style="margin-top: 1rem;">
+                        <button class="btn btn-success btn-small" onclick="approveAnalysis('${item.id}')">Approve</button>
+                        <button class="btn btn-danger btn-small" onclick="rejectAnalysis('${item.id}')">Reject</button>
                         <button class="btn btn-primary btn-small" onclick="viewFullAnalysis('${item.id}')">View Full</button>
                     </div>
                 </div>
             `;
+            div.addEventListener('click', (e) => {
+                if (e.target.tagName === 'INPUT' || e.target.tagName === 'BUTTON') return;
+                div.classList.toggle('expanded');
+            });
             return div;
         }
 
@@ -1410,30 +1350,6 @@
             }
         }
 
-        async function rejectTemplate(templateName) {
-            try {
-                const templates = await apiCall('/templates');
-                const allTemplates = [...(templates.approved || []), ...(templates.unapproved || [])];
-                const template = allTemplates.find(t => t.name === templateName);
-
-                if (!template) {
-                    alert('Template not found');
-                    return;
-                }
-
-                await apiCall('/template/reject', {
-                    method: 'POST',
-                    body: JSON.stringify({ template: template.filename })
-                });
-
-                logMessage('task-log', 'warning', `Template rejected: ${templateName}`);
-                await loadTemplates();
-                await refreshReviewQueue();
-
-            } catch (error) {
-                logMessage('task-log', 'error', `Failed to reject template: ${error.message}`);
-            }
-        }
 
         async function approveAnalysis(id) {
             try {
@@ -1469,28 +1385,22 @@
 
 
         async function approveSelectedTemplates() {
-            const selected = document.querySelectorAll('.review-template:checked');
+            const selected = document.querySelectorAll('.review-select:checked');
             if (selected.length === 0) {
-                alert('Please select at least one template');
+                alert('Please select at least one analysis');
                 return;
             }
-            for (const cb of selected) {
-                await approveTemplate(cb.value);
-            }
-            await refreshReviewQueue();
-            await loadTemplates();
-            refreshStatus();
-        }
 
-        async function rejectSelectedTemplates() {
-            const selected = document.querySelectorAll('.review-template:checked');
-            if (selected.length === 0) {
-                alert('Please select at least one template');
-                return;
+            const templateNames = new Set();
+            selected.forEach(cb => {
+                const name = cb.getAttribute('data-template');
+                if (name) templateNames.add(name);
+            });
+
+            for (const name of templateNames) {
+                await approveTemplate(name);
             }
-            for (const cb of selected) {
-                await rejectTemplate(cb.value);
-            }
+
             await refreshReviewQueue();
             await loadTemplates();
             refreshStatus();

--- a/night_watcher_web.py
+++ b/night_watcher_web.py
@@ -31,18 +31,10 @@ CORS(app)
 night_watcher = None
 current_task = None
 task_thread = None
-task_status = {
-    "running": False,
-    "task": None,
-    "progress": 0,
-    "messages": []
-}
+task_status = {"running": False, "task": None, "progress": 0, "messages": []}
 
 # Statistics cache
-stats_cache = {
-    "last_update": None,
-    "data": {}
-}
+stats_cache = {"last_update": None, "data": {}}
 
 # Review queue storage (simple file-based)
 REVIEW_QUEUE_FILE = "data/review_queue.json"
@@ -62,11 +54,9 @@ def init_night_watcher():
 def add_log_message(level, message):
     """Add message to task status log."""
     timestamp = datetime.now().strftime("%H:%M:%S")
-    task_status["messages"].append({
-        "time": timestamp,
-        "level": level,
-        "message": message
-    })
+    task_status["messages"].append(
+        {"time": timestamp, "level": level, "message": message}
+    )
     # Keep only last 100 messages
     if len(task_status["messages"]) > 100:
         task_status["messages"] = task_status["messages"][-100:]
@@ -78,21 +68,27 @@ def validate_key_pair(private_key_pem: str, public_key_pem: str) -> dict:
         from cryptography.hazmat.primitives import serialization, hashes
         from cryptography.hazmat.primitives.asymmetric import padding
 
-        private_key = serialization.load_pem_private_key(private_key_pem.encode(), password=None)
+        private_key = serialization.load_pem_private_key(
+            private_key_pem.encode(), password=None
+        )
         public_key = serialization.load_pem_public_key(public_key_pem.encode())
 
         test_data = b"Night_watcher key validation test"
         signature = private_key.sign(
             test_data,
-            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
-            hashes.SHA256()
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH
+            ),
+            hashes.SHA256(),
         )
 
         public_key.verify(
             signature,
             test_data,
-            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
-            hashes.SHA256()
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH
+            ),
+            hashes.SHA256(),
         )
 
         return {"valid": True, "message": "Key pair validation successful"}
@@ -105,7 +101,7 @@ def load_review_queue():
     """Load review queue from file."""
     if os.path.exists(REVIEW_QUEUE_FILE):
         try:
-            with open(REVIEW_QUEUE_FILE, 'r', encoding='utf-8') as f:
+            with open(REVIEW_QUEUE_FILE, "r", encoding="utf-8") as f:
                 return json.load(f)
         except:
             return []
@@ -116,7 +112,7 @@ def save_review_queue(queue):
     """Save review queue to file."""
     try:
         os.makedirs(os.path.dirname(REVIEW_QUEUE_FILE), exist_ok=True)
-        with open(REVIEW_QUEUE_FILE, 'w', encoding='utf-8') as f:
+        with open(REVIEW_QUEUE_FILE, "w", encoding="utf-8") as f:
             json.dump(queue, f, indent=2)
     except Exception as e:
         logger.error(f"Failed to save review queue: {e}")
@@ -126,19 +122,19 @@ def scan_for_review_items():
     """Scan analyzed directory for items needing review."""
     review_items = []
     analyzed_dir = "data/analyzed"
-    
+
     if not os.path.exists(analyzed_dir):
         return review_items
-    
+
     for filename in os.listdir(analyzed_dir):
         if not filename.startswith("analysis_"):
             continue
-            
+
         try:
             filepath = os.path.join(analyzed_dir, filename)
-            with open(filepath, 'r', encoding='utf-8') as f:
+            with open(filepath, "r", encoding="utf-8") as f:
                 analysis = json.load(f)
-            
+
             validation = analysis.get("validation", {})
             if validation.get("status") == "REVIEW":
                 # Create review item
@@ -146,129 +142,143 @@ def scan_for_review_items():
                     "id": filename[:-5],  # Remove .json
                     "filename": filename,
                     "timestamp": analysis.get("timestamp"),
-                    "template_name": analysis.get("template_info", {}).get("name", "Unknown"),
-                    "template_status": analysis.get("template_info", {}).get("status", "Unknown"),
+                    "template_name": analysis.get("template_info", {}).get(
+                        "name", "Unknown"
+                    ),
+                    "template_status": analysis.get("template_info", {}).get(
+                        "status", "Unknown"
+                    ),
                     "validation_status": validation.get("status"),
                     "validation_reason": validation.get("reason", ""),
                     "article": analysis.get("article", {}),
                     "manipulation_score": analysis.get("manipulation_score", 0),
                     "concern_level": analysis.get("concern_level", "Unknown"),
-                    "authoritarian_indicators": analysis.get("authoritarian_indicators", [])
+                    "authoritarian_indicators": analysis.get(
+                        "authoritarian_indicators", []
+                    ),
                 }
                 review_items.append(review_item)
-                
+
         except Exception as e:
             logger.error(f"Error scanning {filename}: {e}")
-    
+
     return review_items
 
 
-@app.route('/')
+@app.route("/")
 def dashboard():
     """Serve the dashboard HTML."""
     # Read the dashboard HTML file with UTF-8 encoding
-    dashboard_path = os.path.join(os.path.dirname(__file__), 'night_watcher_dashboard.html')
+    dashboard_path = os.path.join(
+        os.path.dirname(__file__), "night_watcher_dashboard.html"
+    )
     if os.path.exists(dashboard_path):
-        with open(dashboard_path, 'r', encoding='utf-8') as f:
+        with open(dashboard_path, "r", encoding="utf-8") as f:
             return f.read()
     else:
         return "<h1>Dashboard not found. Please ensure night_watcher_dashboard.html is in the same directory.</h1>"
 
 
-@app.route('/api/status')
+@app.route("/api/status")
 def api_status():
     """Get current system status."""
     try:
         init_night_watcher()
-        
+
         # Cache status for 5 seconds
         now = datetime.now()
-        if stats_cache["last_update"] and (now - stats_cache["last_update"]).seconds < 5:
+        if (
+            stats_cache["last_update"]
+            and (now - stats_cache["last_update"]).seconds < 5
+        ):
             # But always update certain fields
             status = stats_cache["data"].copy()
         else:
             status = night_watcher.status()
             stats_cache["last_update"] = now
             stats_cache["data"] = status
-        
+
         # Always update these fields
         review_items = scan_for_review_items()
         status["pending_review"] = len(review_items)
-        
+
         # Add specific document counts
         status["total_documents"] = status.get("documents", {}).get("total", 0)
         status["pending_analysis"] = status.get("documents", {}).get("pending", 0)
         status["analyzed_documents"] = status.get("documents", {}).get("analyzed", 0)
-        
+
         # Add graph stats
         kg_stats = status.get("knowledge_graph", {})
         status["graph_nodes"] = kg_stats.get("nodes", 0)
         status["graph_edges"] = kg_stats.get("edges", 0)
-        
+
         # Add vector count
         status["vector_count"] = status.get("vector_store", {}).get("total_vectors", 0)
-        
+
         # Add task status
         status["task_status"] = {
             "running": task_status["running"],
             "current_task": task_status["task"],
-            "progress": task_status["progress"]
+            "progress": task_status["progress"],
         }
-        
+
         # Add system info
         status["system"] = {
             "llm_connected": night_watcher.llm_provider is not None,
-            "llm_type": night_watcher.config.get("llm_provider", {}).get("type", "unknown"),
-            "current_model": getattr(night_watcher.llm_provider, 'model', None) if night_watcher.llm_provider else None
+            "llm_type": night_watcher.config.get("llm_provider", {}).get(
+                "type", "unknown"
+            ),
+            "current_model": (
+                getattr(night_watcher.llm_provider, "model", None)
+                if night_watcher.llm_provider
+                else None
+            ),
         }
-        
+
         return jsonify(status)
     except Exception as e:
         logger.error(f"Status error: {e}")
         return jsonify({"error": str(e)}), 500
 
 
-@app.route('/api/templates')
+@app.route("/api/templates")
 def api_templates():
     """Get available analysis templates grouped by status."""
     try:
-        templates = {
-            "approved": [],
-            "unapproved": []
-        }
-        
+        templates = {"approved": [], "unapproved": []}
+
         # Scan for template files
         template_files = glob.glob("*_analysis.json")
-        
+
         for filename in template_files:
             try:
-                with open(filename, 'r', encoding='utf-8') as f:
+                with open(filename, "r", encoding="utf-8") as f:
                     template_data = json.load(f)
-                
+
                 template_info = {
                     "filename": filename,
                     "name": template_data.get("name", filename),
                     "description": template_data.get("description", ""),
                     "version": template_data.get("version", ""),
                     "status": template_data.get("status", "UNKNOWN"),
-                    "rounds": len(template_data.get("rounds", []))
+                    "rounds": len(template_data.get("rounds", [])),
                 }
-                
+
                 # Group by status
                 if template_data.get("status") == "PRODUCTION":
                     templates["approved"].append(template_info)
                 else:
                     templates["unapproved"].append(template_info)
-                    
+
             except Exception as e:
                 logger.error(f"Error reading template {filename}: {e}")
-        
+
         return jsonify(templates)
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
 
-@app.route('/api/template/approve', methods=['POST'])
+@app.route("/api/template/approve", methods=["POST"])
 def api_approve_template():
     """Approve a template and mark its analyses as valid."""
     try:
@@ -279,18 +289,19 @@ def api_approve_template():
             return jsonify({"error": "Template not found"}), 404
 
         # Load template
-        with open(template_file, 'r', encoding='utf-8') as f:
+        with open(template_file, "r", encoding="utf-8") as f:
             template_data = json.load(f)
 
         template_name = template_data.get("name", os.path.basename(template_file))
 
-        # Update status
-        template_data["status"] = "PRODUCTION"
-        template_data["approved_at"] = datetime.now().isoformat()
-        template_data["approved_by"] = "dashboard_user"
+        # Update status only if template is not already in production
+        if template_data.get("status") != "PRODUCTION":
+            template_data["status"] = "PRODUCTION"
+            template_data["approved_at"] = datetime.now().isoformat()
+            template_data["approved_by"] = "dashboard_user"
 
         # Save updated template
-        with open(template_file, 'w', encoding='utf-8') as f:
+        with open(template_file, "w", encoding="utf-8") as f:
             json.dump(template_data, f, indent=2)
 
         # Update analyses created with this template
@@ -301,15 +312,17 @@ def api_approve_template():
                     continue
                 filepath = os.path.join(analyzed_dir, filename)
                 try:
-                    with open(filepath, 'r', encoding='utf-8') as af:
+                    with open(filepath, "r", encoding="utf-8") as af:
                         analysis = json.load(af)
                     if analysis.get("template_info", {}).get("name") != template_name:
                         continue
                     if analysis.get("validation", {}).get("status") == "REVIEW":
                         analysis["validation"]["status"] = "VALID"
                         analysis["validation"]["approved_by"] = "dashboard_user"
-                        analysis["validation"]["approved_at"] = datetime.now().isoformat()
-                        with open(filepath, 'w', encoding='utf-8') as af:
+                        analysis["validation"][
+                            "approved_at"
+                        ] = datetime.now().isoformat()
+                        with open(filepath, "w", encoding="utf-8") as af:
                             json.dump(analysis, af, indent=2)
                 except Exception as e:
                     logger.error(f"Failed to update analysis {filename}: {e}")
@@ -321,110 +334,56 @@ def api_approve_template():
         return jsonify({"error": str(e)}), 500
 
 
-@app.route('/api/template/reject', methods=['POST'])
-def api_reject_template():
-    """Reject a template and mark its analyses as rejected."""
-    try:
-        data = request.json
-        template_file = data.get("template")
-
-        if not template_file or not os.path.exists(template_file):
-            return jsonify({"error": "Template not found"}), 404
-
-        # Load template
-        with open(template_file, 'r', encoding='utf-8') as f:
-            template_data = json.load(f)
-
-        template_name = template_data.get("name", os.path.basename(template_file))
-
-        # Update status
-        template_data["status"] = "REJECTED"
-        template_data["rejected_at"] = datetime.now().isoformat()
-        template_data["rejected_by"] = "dashboard_user"
-
-        # Save updated template
-        with open(template_file, 'w', encoding='utf-8') as f:
-            json.dump(template_data, f, indent=2)
-
-        # Mark associated analyses as rejected
-        analyzed_dir = "data/analyzed"
-        if os.path.exists(analyzed_dir):
-            for filename in os.listdir(analyzed_dir):
-                if not filename.startswith("analysis_"):
-                    continue
-                filepath = os.path.join(analyzed_dir, filename)
-                try:
-                    with open(filepath, 'r', encoding='utf-8') as af:
-                        analysis = json.load(af)
-                    if analysis.get("template_info", {}).get("name") != template_name:
-                        continue
-                    analysis["validation"]["status"] = "REJECTED"
-                    analysis["validation"]["rejected_by"] = "dashboard_user"
-                    analysis["validation"]["rejected_at"] = datetime.now().isoformat()
-                    with open(filepath, 'w', encoding='utf-8') as af:
-                        json.dump(analysis, af, indent=2)
-                except Exception as e:
-                    logger.error(f"Failed to reject analysis {filename}: {e}")
-
-        add_log_message("warning", f"Template rejected: {template_file}")
-        return jsonify({"status": "rejected"})
-
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
-
-
-@app.route('/api/template/test', methods=['POST'])
+@app.route("/api/template/test", methods=["POST"])
 def api_test_template():
     """Test a template with a single article."""
     try:
         init_night_watcher()
-        
+
         data = request.json or {}
         template = data.get("template", "standard_analysis.json")
         article_content = data.get("article_content")
         article_url = data.get("article_url")
-        
+
         # Run test
         result = night_watcher.test_template(
-            template=template,
-            article_content=article_content,
-            article_url=article_url
+            template=template, article_content=article_content, article_url=article_url
         )
-        
+
         return jsonify(result)
-        
+
     except Exception as e:
         logger.error(f"Template test error: {e}")
         return jsonify({"error": str(e)}), 500
 
 
-@app.route('/api/analysis/<analysis_id>')
+@app.route("/api/analysis/<analysis_id>")
 def api_get_analysis(analysis_id):
     """Get a specific analysis result."""
     try:
         filepath = f"data/analyzed/{analysis_id}.json"
         if not os.path.exists(filepath):
             return jsonify({"error": "Analysis not found"}), 404
-        
-        with open(filepath, 'r', encoding='utf-8') as f:
+
+        with open(filepath, "r", encoding="utf-8") as f:
             analysis = json.load(f)
-        
+
         return jsonify(analysis)
-        
+
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
 
-@app.route('/api/analysis/recent')
+@app.route("/api/analysis/recent")
 def api_recent_analyses():
     """Get recent analysis results."""
     try:
         analyses = []
         analyzed_dir = "data/analyzed"
-        
+
         if not os.path.exists(analyzed_dir):
             return jsonify([])
-        
+
         # Get all analysis files
         files = []
         for filename in os.listdir(analyzed_dir):
@@ -432,47 +391,57 @@ def api_recent_analyses():
                 filepath = os.path.join(analyzed_dir, filename)
                 mtime = os.path.getmtime(filepath)
                 files.append((filename, filepath, mtime))
-        
+
         # Sort by modification time (newest first)
         files.sort(key=lambda x: x[2], reverse=True)
-        
+
         # Get top 20
         for filename, filepath, mtime in files[:20]:
             try:
-                with open(filepath, 'r', encoding='utf-8') as f:
+                with open(filepath, "r", encoding="utf-8") as f:
                     analysis = json.load(f)
-                
-                analyses.append({
-                    "id": filename[:-5],  # Remove .json
-                    "filename": filename,
-                    "timestamp": analysis.get("timestamp"),
-                    "template": analysis.get("template_info", {}).get("name", "Unknown"),
-                    "article_title": analysis.get("article", {}).get("title", "Unknown"),
-                    "article_source": analysis.get("article", {}).get("source", "Unknown"),
-                    "validation_status": analysis.get("validation", {}).get("status", "Unknown"),
-                    "manipulation_score": analysis.get("manipulation_score", 0),
-                    "concern_level": analysis.get("concern_level", "Unknown")
-                })
+
+                analyses.append(
+                    {
+                        "id": filename[:-5],  # Remove .json
+                        "filename": filename,
+                        "timestamp": analysis.get("timestamp"),
+                        "template": analysis.get("template_info", {}).get(
+                            "name", "Unknown"
+                        ),
+                        "article_title": analysis.get("article", {}).get(
+                            "title", "Unknown"
+                        ),
+                        "article_source": analysis.get("article", {}).get(
+                            "source", "Unknown"
+                        ),
+                        "validation_status": analysis.get("validation", {}).get(
+                            "status", "Unknown"
+                        ),
+                        "manipulation_score": analysis.get("manipulation_score", 0),
+                        "concern_level": analysis.get("concern_level", "Unknown"),
+                    }
+                )
             except Exception as e:
                 logger.error(f"Error reading {filename}: {e}")
-        
+
         return jsonify(analyses)
-        
+
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
 
-@app.route('/api/collect', methods=['POST'])
+@app.route("/api/collect", methods=["POST"])
 def api_collect():
     """Start content collection."""
     global task_thread, task_status
-    
+
     if task_status["running"]:
         return jsonify({"error": "Another task is already running"}), 400
-    
+
     data = request.json or {}
     mode = data.get("mode", "auto")
-    
+
     def run_collection():
         task_status["running"] = True
         task_status["task"] = "collection"
@@ -483,21 +452,25 @@ def api_collect():
             if event.get("type") == "article":
                 add_log_message("info", f"Collected: {event.get('title')}")
             elif event.get("type") == "error":
-                add_log_message("error", f"{event.get('source')}: {event.get('message')}")
+                add_log_message(
+                    "error", f"{event.get('source')}: {event.get('message')}"
+                )
             elif event.get("type") == "cancelled":
                 add_log_message("warning", "Collection cancelled")
 
         try:
             init_night_watcher()
             result = night_watcher.collect(mode=mode, callback=progress)
-            
+
             articles_count = len(result.get("articles", []))
             if night_watcher.collector.cancelled:
                 add_log_message("warning", "Collection stopped by user")
             else:
-                add_log_message("success", f"Collection completed: {articles_count} articles")
+                add_log_message(
+                    "success", f"Collection completed: {articles_count} articles"
+                )
             task_status["progress"] = 100
-            
+
         except Exception as e:
             add_log_message("error", f"Collection failed: {str(e)}")
         finally:
@@ -505,14 +478,14 @@ def api_collect():
             task_status["task"] = None
             # Clear cache to update status
             stats_cache["last_update"] = None
-    
+
     task_thread = threading.Thread(target=run_collection)
     task_thread.start()
 
     return jsonify({"status": "started"})
 
 
-@app.route('/api/collect/stop', methods=['POST'])
+@app.route("/api/collect/stop", methods=["POST"])
 def api_collect_stop():
     """Request stopping an ongoing collection."""
     try:
@@ -524,54 +497,61 @@ def api_collect_stop():
         return jsonify({"error": str(e)}), 400
 
 
-@app.route('/api/analyze', methods=['POST'])
+@app.route("/api/analyze", methods=["POST"])
 def api_analyze():
     """Start content analysis."""
     global task_thread, task_status
-    
+
     if task_status["running"]:
         return jsonify({"error": "Another task is already running"}), 400
-    
+
     data = request.json or {}
     max_articles = data.get("max_articles", 20)
     templates = data.get("templates", [])
     target = data.get("target", "unanalyzed")
     since_date = data.get("since_date")
-    
+
     if not templates:
         return jsonify({"error": "No templates selected"}), 400
-    
+
     def run_analysis():
         task_status["running"] = True
         task_status["task"] = "analysis"
         task_status["progress"] = 0
-        add_log_message("info", f"Starting analysis (templates: {len(templates)}, target: {target})")
-        
+        add_log_message(
+            "info", f"Starting analysis (templates: {len(templates)}, target: {target})"
+        )
+
         try:
             init_night_watcher()
-            
+
             # Check if analyzer is available
             if not night_watcher.analyzer:
                 add_log_message("error", "Analyzer not available - check LLM provider")
                 task_status["progress"] = 100
                 return
-            
+
             # Run analysis
             result = night_watcher.analyze(
-                max_articles=max_articles, 
+                max_articles=max_articles,
                 templates=templates,
                 target=target,
-                since_date=since_date
+                since_date=since_date,
             )
-            
+
             if result.get("status") == "no_documents":
-                add_log_message("warning", "No documents to analyze for selected target")
+                add_log_message(
+                    "warning", "No documents to analyze for selected target"
+                )
             else:
                 analyzed_count = result.get("analyzed", 0)
-                add_log_message("success", f"Analysis completed: {analyzed_count} documents with {len(templates)} templates")
-            
+                add_log_message(
+                    "success",
+                    f"Analysis completed: {analyzed_count} documents with {len(templates)} templates",
+                )
+
             task_status["progress"] = 100
-            
+
         except Exception as e:
             add_log_message("error", f"Analysis failed: {str(e)}")
             logger.error(f"Analysis error details: {e}", exc_info=True)
@@ -580,70 +560,14 @@ def api_analyze():
             task_status["task"] = None
             # Clear cache to update status
             stats_cache["last_update"] = None
-    
+
     task_thread = threading.Thread(target=run_analysis)
     task_thread.start()
-    
+
     return jsonify({"status": "started"})
 
 
-@app.route('/api/validate-template', methods=['POST'])
-def api_validate_template():
-    """Validate a template's JSON output capability."""
-    try:
-        data = request.json or {}
-        template_file = data.get("template")
-        
-        if not template_file:
-            return jsonify({"error": "No template specified"}), 400
-        
-        # Load template
-        if not os.path.exists(template_file):
-            return jsonify({"error": "Template not found"}), 404
-        
-        with open(template_file, 'r', encoding='utf-8') as f:
-            template = json.load(f)
-        
-        # Validate structure
-        issues = []
-        
-        if "rounds" not in template:
-            issues.append("Missing 'rounds' array")
-        else:
-            for i, round_config in enumerate(template["rounds"]):
-                round_name = round_config.get("name", f"Round {i+1}")
-                
-                # Check for JSON-critical rounds
-                if round_name in ["fact_extraction", "node_extraction", "edge_extraction", 
-                                  "node_deduplication", "edge_enrichment", "package_ingestion"]:
-                    prompt = round_config.get("prompt", "")
-                    
-                    # Check for JSON instructions
-                    if "json" not in prompt.lower():
-                        issues.append(f"{round_name}: Prompt should mention JSON format")
-                    
-                    if "must be ONLY" not in prompt and "ENTIRE response" not in prompt:
-                        issues.append(f"{round_name}: Should emphasize JSON-only response")
-                    
-                    # Check for format examples
-                    if "{" not in prompt or "}" not in prompt:
-                        issues.append(f"{round_name}: Should include JSON format example")
-        
-        return jsonify({
-            "valid": len(issues) == 0,
-            "issues": issues,
-            "template": {
-                "name": template.get("name"),
-                "status": template.get("status"),
-                "rounds": len(template.get("rounds", []))
-            }
-        })
-        
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
-
-
-@app.route('/api/review-queue')
+@app.route("/api/review-queue")
 def api_review_queue():
     """Get review queue items."""
     try:
@@ -653,99 +577,102 @@ def api_review_queue():
         return jsonify({"error": str(e)}), 500
 
 
-@app.route('/api/review-queue/approve', methods=['POST'])
+@app.route("/api/review-queue/approve", methods=["POST"])
 def api_approve_analysis():
     """Approve an analysis."""
     try:
         data = request.json
         analysis_id = data.get("analysis_id")
         notes = data.get("notes", "")
-        
+
         # Load analysis file
         filepath = f"data/analyzed/{analysis_id}.json"
         if not os.path.exists(filepath):
             return jsonify({"error": "Analysis not found"}), 404
-        
-        with open(filepath, 'r', encoding='utf-8') as f:
+
+        with open(filepath, "r", encoding="utf-8") as f:
             analysis = json.load(f)
-        
+
         # Update validation status
         analysis["validation"]["status"] = "VALID"
         analysis["validation"]["approved_by"] = "dashboard_user"
         analysis["validation"]["approved_at"] = datetime.now().isoformat()
         analysis["validation"]["notes"] = notes
-        
+
         # Save updated analysis
-        with open(filepath, 'w', encoding='utf-8') as f:
+        with open(filepath, "w", encoding="utf-8") as f:
             json.dump(analysis, f, indent=2)
-        
+
         # Clear cache to force status refresh
         stats_cache["last_update"] = None
-        
+
         return jsonify({"status": "approved"})
-        
+
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
 
-@app.route('/api/review-queue/reject', methods=['POST'])
+@app.route("/api/review-queue/reject", methods=["POST"])
 def api_reject_analysis():
     """Reject an analysis."""
     try:
         data = request.json
         analysis_id = data.get("analysis_id")
         notes = data.get("notes", "")
-        
+
         # Load analysis file
         filepath = f"data/analyzed/{analysis_id}.json"
         if not os.path.exists(filepath):
             return jsonify({"error": "Analysis not found"}), 404
-        
-        with open(filepath, 'r', encoding='utf-8') as f:
+
+        with open(filepath, "r", encoding="utf-8") as f:
             analysis = json.load(f)
-        
+
         # Update validation status
         analysis["validation"]["status"] = "REJECTED"
         analysis["validation"]["rejected_by"] = "dashboard_user"
         analysis["validation"]["rejected_at"] = datetime.now().isoformat()
         analysis["validation"]["notes"] = notes
-        
+
         # Save updated analysis
-        with open(filepath, 'w', encoding='utf-8') as f:
+        with open(filepath, "w", encoding="utf-8") as f:
             json.dump(analysis, f, indent=2)
-        
+
         # Clear cache to force status refresh
         stats_cache["last_update"] = None
-        
+
         return jsonify({"status": "rejected"})
-        
+
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
 
-@app.route('/api/build-kg', methods=['POST'])
+@app.route("/api/build-kg", methods=["POST"])
 def api_build_kg():
     """Build knowledge graph."""
     global task_thread, task_status
-    
+
     if task_status["running"]:
         return jsonify({"error": "Another task is already running"}), 400
-    
+
     def run_kg_build():
         task_status["running"] = True
         task_status["task"] = "knowledge_graph"
         task_status["progress"] = 0
         add_log_message("info", "Building knowledge graph from analyses")
-        
+
         try:
             init_night_watcher()
             result = night_watcher.build_kg()
-            
+
             processed = result.get("processed", 0)
             temporal = result.get("temporal_relations", 0)
-            add_log_message("success", f"KG built: {processed} analyses, {temporal} temporal relations")
+            add_log_message(
+                "success",
+                f"KG built: {processed} analyses, {temporal} temporal relations",
+            )
             task_status["progress"] = 100
-            
+
         except Exception as e:
             add_log_message("error", f"KG build failed: {str(e)}")
         finally:
@@ -753,35 +680,37 @@ def api_build_kg():
             task_status["task"] = None
             # Clear cache to update status
             stats_cache["last_update"] = None
-    
+
     task_thread = threading.Thread(target=run_kg_build)
     task_thread.start()
-    
+
     return jsonify({"status": "started"})
 
 
-@app.route('/api/sync-vectors', methods=['POST'])
+@app.route("/api/sync-vectors", methods=["POST"])
 def api_sync_vectors():
     """Sync vector store."""
     global task_thread, task_status
-    
+
     if task_status["running"]:
         return jsonify({"error": "Another task is already running"}), 400
-    
+
     def run_sync():
         task_status["running"] = True
         task_status["task"] = "vector_sync"
         task_status["progress"] = 0
         add_log_message("info", "Synchronizing vector store with knowledge graph")
-        
+
         try:
             init_night_watcher()
             result = night_watcher.sync_vectors()
-            
+
             nodes_added = result.get("nodes_added", 0)
-            add_log_message("success", f"Vector sync completed: {nodes_added} nodes added")
+            add_log_message(
+                "success", f"Vector sync completed: {nodes_added} nodes added"
+            )
             task_status["progress"] = 100
-            
+
         except Exception as e:
             add_log_message("error", f"Vector sync failed: {str(e)}")
         finally:
@@ -789,32 +718,34 @@ def api_sync_vectors():
             task_status["task"] = None
             # Clear cache to update status
             stats_cache["last_update"] = None
-    
+
     task_thread = threading.Thread(target=run_sync)
     task_thread.start()
-    
+
     return jsonify({"status": "started"})
 
 
-@app.route('/api/task-status')
+@app.route("/api/task-status")
 def api_task_status():
     """Get current task status and logs."""
-    return jsonify({
-        "running": task_status["running"],
-        "task": task_status["task"],
-        "progress": task_status["progress"],
-        "messages": task_status["messages"][-20:]  # Last 20 messages
-    })
+    return jsonify(
+        {
+            "running": task_status["running"],
+            "task": task_status["task"],
+            "progress": task_status["progress"],
+            "messages": task_status["messages"][-20:],  # Last 20 messages
+        }
+    )
 
 
-@app.route('/api/public-key', methods=['GET', 'POST'])
+@app.route("/api/public-key", methods=["GET", "POST"])
 def api_public_key():
     """Retrieve or update stored public key."""
     init_night_watcher()
 
-    if request.method == 'GET':
+    if request.method == "GET":
         if os.path.exists(PUBLIC_KEY_FILE):
-            with open(PUBLIC_KEY_FILE, 'r', encoding='utf-8') as f:
+            with open(PUBLIC_KEY_FILE, "r", encoding="utf-8") as f:
                 key = f.read()
         else:
             key = ""
@@ -823,24 +754,27 @@ def api_public_key():
     data = request.json or {}
     key = data.get("public_key", "")
     os.makedirs(os.path.dirname(PUBLIC_KEY_FILE), exist_ok=True)
-    with open(PUBLIC_KEY_FILE, 'w', encoding='utf-8') as f:
+    with open(PUBLIC_KEY_FILE, "w", encoding="utf-8") as f:
         f.write(key)
 
     night_watcher.config.setdefault("export", {})["public_key"] = PUBLIC_KEY_FILE
-    with open(night_watcher.config_path, 'w', encoding='utf-8') as f:
+    with open(night_watcher.config_path, "w", encoding="utf-8") as f:
         json.dump(night_watcher.config, f, indent=2)
 
     add_log_message("success", "Public key saved")
     return jsonify({"status": "saved"})
 
 
-@app.route('/api/export', methods=['POST'])
+@app.route("/api/export", methods=["POST"])
 def api_export():
     """Create a signed export archive."""
     try:
         init_night_watcher()
         data = request.json or {}
-        filename = data.get("filename") or f"night_watcher_{datetime.now().strftime('%Y%m%d_%H%M%S')}.tar.gz"
+        filename = (
+            data.get("filename")
+            or f"night_watcher_{datetime.now().strftime('%Y%m%d_%H%M%S')}.tar.gz"
+        )
         export_dir = os.path.join(night_watcher.base_dir, "exports")
         os.makedirs(export_dir, exist_ok=True)
         output_path = os.path.join(export_dir, filename)
@@ -849,7 +783,9 @@ def api_export():
         from export_artifact import export_artifact
 
         private_key = night_watcher.config.get("export", {}).get("private_key")
-        public_key = night_watcher.config.get("export", {}).get("public_key", PUBLIC_KEY_FILE if os.path.exists(PUBLIC_KEY_FILE) else None)
+        public_key = night_watcher.config.get("export", {}).get(
+            "public_key", PUBLIC_KEY_FILE if os.path.exists(PUBLIC_KEY_FILE) else None
+        )
 
         export_artifact(
             output_path,
@@ -868,7 +804,7 @@ def api_export():
         return jsonify({"error": str(e)}), 400
 
 
-@app.route('/api/export/status')
+@app.route("/api/export/status")
 def api_export_status():
     """Get export system status and version info."""
     init_night_watcher()
@@ -877,7 +813,7 @@ def api_export_status():
     return jsonify({"current_version": version})
 
 
-@app.route('/api/export/staging')
+@app.route("/api/export/staging")
 def api_staging_list():
     """List files in staging area."""
     init_night_watcher()
@@ -886,86 +822,93 @@ def api_staging_list():
     return jsonify({"files": files})
 
 
-@app.route('/api/export/staging/add', methods=['POST'])
+@app.route("/api/export/staging/add", methods=["POST"])
 def api_staging_add():
     """Add file to staging area."""
     init_night_watcher()
-    path = (request.json or {}).get('file')
+    path = (request.json or {}).get("file")
     orchestrator = night_watcher.get_export_orchestrator()
     orchestrator.staging_mgr.add_file(path)
     return jsonify({"status": "added"})
 
 
-@app.route('/api/export/staging/remove', methods=['POST'])
+@app.route("/api/export/staging/remove", methods=["POST"])
 def api_staging_remove():
     """Remove file from staging area."""
     init_night_watcher()
     data = request.json or {}
     orchestrator = night_watcher.get_export_orchestrator()
-    if data.get('clear'):
+    if data.get("clear"):
         orchestrator.staging_mgr.clear_staging()
     else:
-        orchestrator.staging_mgr.remove_file(data.get('file'))
+        orchestrator.staging_mgr.remove_file(data.get("file"))
     return jsonify({"status": "removed"})
 
 
-@app.route('/api/export/validate-keys', methods=['POST'])
+@app.route("/api/export/validate-keys", methods=["POST"])
 def api_validate_keys():
     """Validate private/public key pair."""
     data = request.json or {}
-    result = validate_key_pair(data.get('private_key', ''), data.get('public_key', ''))
-    status = 200 if result.get('valid') else 400
+    result = validate_key_pair(data.get("private_key", ""), data.get("public_key", ""))
+    status = 200 if result.get("valid") else 400
     return jsonify(result), status
 
 
-@app.route('/api/export/create-package', methods=['POST'])
+@app.route("/api/export/create-package", methods=["POST"])
 def api_create_package_v2():
     """Create package with user provided keys."""
     try:
         init_night_watcher()
         data = request.json or {}
-        package_type = data.get('package_type', 'v001')
-        private_key = data.get('private_key', '')
-        public_key = data.get('public_key', '')
-        staging_files = data.get('staging_files', [])
+        package_type = data.get("package_type", "v001")
+        private_key = data.get("private_key", "")
+        public_key = data.get("public_key", "")
+        staging_files = data.get("staging_files", [])
 
         validation = validate_key_pair(private_key, public_key)
-        if not validation['valid']:
-            return jsonify({"error": f"Key validation failed: {validation['message']}"}), 400
+        if not validation["valid"]:
+            return (
+                jsonify({"error": f"Key validation failed: {validation['message']}"}),
+                400,
+            )
 
         orchestrator = night_watcher.get_export_orchestrator()
-        result = orchestrator.create_package(package_type, private_key, public_key, staging_files)
+        result = orchestrator.create_package(
+            package_type, private_key, public_key, staging_files
+        )
 
-        if result.get('success', True):
+        if result.get("success", True):
             return jsonify(result)
         else:
-            return jsonify({"error": result.get('error', 'unknown')}), 400
+            return jsonify({"error": result.get("error", "unknown")}), 400
 
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
 
-@app.route('/api/export/create', methods=['POST'])
+@app.route("/api/export/create", methods=["POST"])
 def api_create_package():
     """Create distribution package."""
     init_night_watcher()
     data = request.json or {}
     orchestrator = night_watcher.get_export_orchestrator()
-    pkg_type = data.get('type', 'v001')
+    pkg_type = data.get("type", "v001")
 
-    priv = data.get('private_key')
-    pub = data.get('public_key')
-    full_v2 = data.get('full_since_v2', False)
+    priv = data.get("private_key")
+    pub = data.get("public_key")
+    full_v2 = data.get("full_since_v2", False)
 
-    if pkg_type == 'v001':
+    if pkg_type == "v001":
         result = orchestrator.create_v001_package(priv, pub)
     else:
-        result = orchestrator.create_update_package(pkg_type, priv, pub, full_since_v2=full_v2)
+        result = orchestrator.create_update_package(
+            pkg_type, priv, pub, full_since_v2=full_v2
+        )
 
     return jsonify(result)
 
 
-@app.route('/api/export/history')
+@app.route("/api/export/history")
 def api_export_history():
     """Get export history and logs."""
     init_night_watcher()
@@ -973,15 +916,16 @@ def api_export_history():
     history = orchestrator.version_mgr.get_export_history()
     return jsonify(history)
 
-@app.route('/api/config', methods=['GET', 'POST'])
+
+@app.route("/api/config", methods=["GET", "POST"])
 def api_config():
     """Get or update configuration."""
     init_night_watcher()
-    
-    if request.method == 'GET':
+
+    if request.method == "GET":
         return jsonify(night_watcher.config)
-    
-    elif request.method == 'POST':
+
+    elif request.method == "POST":
         try:
             new_config = request.json or {}
 
@@ -997,7 +941,9 @@ def api_config():
             if "llm_provider" in new_config and "model" in new_config["llm_provider"]:
                 model = new_config["llm_provider"]["model"]
                 # Update the provider directly if it exists
-                if night_watcher.llm_provider and hasattr(night_watcher.llm_provider, 'update_model'):
+                if night_watcher.llm_provider and hasattr(
+                    night_watcher.llm_provider, "update_model"
+                ):
                     night_watcher.llm_provider.update_model(model)
                     add_log_message("success", f"Model updated to: {model}")
 
@@ -1005,13 +951,22 @@ def api_config():
             night_watcher.config = deep_update(night_watcher.config, new_config)
 
             # Save to file
-            with open(night_watcher.config_path, 'w', encoding='utf-8') as f:
+            with open(night_watcher.config_path, "w", encoding="utf-8") as f:
                 json.dump(night_watcher.config, f, indent=2)
 
             # Reinitialize components if needed
-            if "llm_provider" in new_config and ("type" in new_config["llm_provider"] or "api_key" in new_config["llm_provider"]):
-                night_watcher.llm_provider = providers.initialize_llm_provider(night_watcher.config)
-                night_watcher.analyzer = ContentAnalyzer(night_watcher.llm_provider) if night_watcher.llm_provider else None
+            if "llm_provider" in new_config and (
+                "type" in new_config["llm_provider"]
+                or "api_key" in new_config["llm_provider"]
+            ):
+                night_watcher.llm_provider = providers.initialize_llm_provider(
+                    night_watcher.config
+                )
+                night_watcher.analyzer = (
+                    ContentAnalyzer(night_watcher.llm_provider)
+                    if night_watcher.llm_provider
+                    else None
+                )
                 add_log_message("success", "LLM provider reinitialized")
 
             add_log_message("success", "Configuration updated")
@@ -1022,12 +977,14 @@ def api_config():
             return jsonify({"error": str(e)}), 400
 
 
-@app.route('/api/llm-models')
+@app.route("/api/llm-models")
 def api_llm_models():
     """Return available models from LM Studio."""
     init_night_watcher()
     try:
-        if night_watcher.llm_provider and hasattr(night_watcher.llm_provider, 'list_models'):
+        if night_watcher.llm_provider and hasattr(
+            night_watcher.llm_provider, "list_models"
+        ):
             models = night_watcher.llm_provider.list_models()
             return jsonify(models)
         else:
@@ -1037,7 +994,7 @@ def api_llm_models():
         return jsonify([])
 
 
-@app.route('/api/sources')
+@app.route("/api/sources")
 def api_sources():
     """Get content sources."""
     init_night_watcher()
@@ -1045,28 +1002,31 @@ def api_sources():
     return jsonify(sources)
 
 
-@app.route('/api/sources/add', methods=['POST'])
+@app.route("/api/sources/add", methods=["POST"])
 def api_add_source():
     """Add a new content source."""
     try:
         init_night_watcher()
         source_data = request.json
-        
+
         if night_watcher.collector.add_source(source_data):
             # Save config
-            with open(night_watcher.config_path, 'w', encoding='utf-8') as f:
+            with open(night_watcher.config_path, "w", encoding="utf-8") as f:
                 json.dump(night_watcher.config, f, indent=2)
-            
-            add_log_message("success", f"Added source: {source_data.get('name', source_data.get('url'))}")
+
+            add_log_message(
+                "success",
+                f"Added source: {source_data.get('name', source_data.get('url'))}",
+            )
             return jsonify({"status": "added"})
         else:
             return jsonify({"error": "Failed to add source"}), 400
-            
+
     except Exception as e:
         return jsonify({"error": str(e)}), 400
 
 
-@app.route('/api/sources/update', methods=['POST'])
+@app.route("/api/sources/update", methods=["POST"])
 def api_update_source():
     """Update an existing content source."""
     try:
@@ -1091,7 +1051,7 @@ def api_update_source():
 
         night_watcher.collector.sources = sources
 
-        with open(night_watcher.config_path, 'w', encoding='utf-8') as f:
+        with open(night_watcher.config_path, "w", encoding="utf-8") as f:
             json.dump(night_watcher.config, f, indent=2)
 
         add_log_message("success", f"Updated source limit for {url}")
@@ -1101,7 +1061,7 @@ def api_update_source():
         return jsonify({"error": str(e)}), 400
 
 
-@app.route('/api/sources/set-limit', methods=['POST'])
+@app.route("/api/sources/set-limit", methods=["POST"])
 def api_set_source_limit():
     """Set article limit for all sources."""
     try:
@@ -1119,7 +1079,7 @@ def api_set_source_limit():
         night_watcher.collector.sources = sources
         night_watcher.config["content_collection"]["article_limit"] = int(limit)
 
-        with open(night_watcher.config_path, 'w', encoding='utf-8') as f:
+        with open(night_watcher.config_path, "w", encoding="utf-8") as f:
             json.dump(night_watcher.config, f, indent=2)
 
         add_log_message("success", f"Set article limit for all sources: {limit}")
@@ -1129,7 +1089,7 @@ def api_set_source_limit():
         return jsonify({"error": str(e)}), 400
 
 
-@app.route('/api/search', methods=['POST'])
+@app.route("/api/search", methods=["POST"])
 def api_search():
     """Search vector store."""
     try:
@@ -1138,74 +1098,73 @@ def api_search():
         query = data.get("query", "")
         node_type = data.get("node_type")
         limit = data.get("limit", 10)
-        
+
         results = night_watcher.vector_store.search(
-            query=query,
-            item_type=node_type,
-            limit=limit
+            query=query, item_type=node_type, limit=limit
         )
-        
+
         return jsonify(results)
-        
+
     except Exception as e:
         return jsonify({"error": str(e)}), 400
 
 
-@app.route('/api/test-llm', methods=['POST'])
+@app.route("/api/test-llm", methods=["POST"])
 def api_test_llm():
     """Test LLM connection."""
     try:
         init_night_watcher()
-        
+
         if not night_watcher.llm_provider:
             return jsonify({"error": "No LLM provider configured"}), 400
-        
+
         # Simple test prompt
         result = night_watcher.llm_provider.complete(
-            prompt="Say 'Connection successful!' and nothing else.",
-            max_tokens=20
+            prompt="Say 'Connection successful!' and nothing else.", max_tokens=20
         )
-        
+
         if "error" in result:
             return jsonify({"error": result["error"]}), 400
-        
+
         # Extract text from response
         text = result.get("choices", [{}])[0].get("text", "")
-        
-        return jsonify({
-            "status": "connected",
-            "response": text,
-            "model": getattr(night_watcher.llm_provider, 'model', 'unknown')
-        })
-        
+
+        return jsonify(
+            {
+                "status": "connected",
+                "response": text,
+                "model": getattr(night_watcher.llm_provider, "model", "unknown"),
+            }
+        )
+
     except Exception as e:
         logger.error(f"LLM test error: {e}")
         return jsonify({"error": str(e)}), 400
 
 
-@app.route('/api/pipeline', methods=['POST'])
+@app.route("/api/pipeline", methods=["POST"])
 def api_pipeline():
     """Run full pipeline."""
     global task_thread, task_status
-    
+
     if task_status["running"]:
         return jsonify({"error": "Another task is already running"}), 400
-    
+
     def run_pipeline():
         task_status["running"] = True
         task_status["task"] = "full_pipeline"
         task_status["progress"] = 0
-        
+
         try:
             init_night_watcher()
-            
+
             # Collection
             add_log_message("info", "Starting collection phase")
             task_status["progress"] = 10
             collect_result = night_watcher.collect()
             articles_count = len(collect_result.get("articles", []))
             add_log_message("success", f"Collected {articles_count} articles")
-            
+
             if articles_count > 0:
                 # Analysis
                 add_log_message("info", "Starting analysis phase")
@@ -1213,23 +1172,28 @@ def api_pipeline():
                 analyze_result = night_watcher.analyze()
                 analyzed = analyze_result.get("analyzed", 0)
                 add_log_message("success", f"Analyzed {analyzed} documents")
-                
+
                 if analyzed > 0:
                     # Knowledge Graph
                     add_log_message("info", "Building knowledge graph")
                     task_status["progress"] = 70
                     kg_result = night_watcher.build_kg()
-                    add_log_message("success", f"Processed {kg_result.get('processed', 0)} analyses")
-                    
+                    add_log_message(
+                        "success", f"Processed {kg_result.get('processed', 0)} analyses"
+                    )
+
                     # Vector Sync
                     add_log_message("info", "Synchronizing vectors")
                     task_status["progress"] = 90
                     vector_result = night_watcher.sync_vectors()
-                    add_log_message("success", f"Synced {vector_result.get('nodes_added', 0)} vectors")
-            
+                    add_log_message(
+                        "success",
+                        f"Synced {vector_result.get('nodes_added', 0)} vectors",
+                    )
+
             task_status["progress"] = 100
             add_log_message("success", "Pipeline completed successfully")
-            
+
         except Exception as e:
             add_log_message("error", f"Pipeline failed: {str(e)}")
         finally:
@@ -1237,33 +1201,33 @@ def api_pipeline():
             task_status["task"] = None
             # Clear cache to update status
             stats_cache["last_update"] = None
-    
+
     task_thread = threading.Thread(target=run_pipeline)
     task_thread.start()
-    
+
     return jsonify({"status": "started"})
 
 
 def main():
     """Main entry point."""
     import argparse
-    
+
     parser = argparse.ArgumentParser(description="Night_watcher Web Server")
     parser.add_argument("--host", default="127.0.0.1", help="Host to bind to")
     parser.add_argument("--port", type=int, default=5000, help="Port to bind to")
     parser.add_argument("--debug", action="store_true", help="Enable debug mode")
-    
+
     args = parser.parse_args()
-    
+
     # Initialize Night_watcher on startup
     init_night_watcher()
-    
+
     # Run Flask app
     print(f"\n🌙 Night_watcher Web Server")
     print(f"Dashboard: http://{args.host}:{args.port}")
     print(f"API Base: http://{args.host}:{args.port}/api/")
     print("\nPress Ctrl+C to stop\n")
-    
+
     app.run(host=args.host, port=args.port, debug=args.debug)
 
 


### PR DESCRIPTION
## Summary
- drop template rejection logic and remove validation endpoint
- update dashboard to remove validation UI and allow approving templates from selected analyses
- change `event_analysis.json` status to TESTING
- only move templates from TESTING to PRODUCTION when approving
- restore ability to view each analysis result and approve or reject it from the review queue

## Testing
- `pytest -q` *(fails: Can't load the model for 'sentence-transformers/all-MiniLM-L6-v2')*

------
https://chatgpt.com/codex/tasks/task_e_6854dbe6f4f08332a76caaada2618598