### PR TITLE
Add event intelligence dashboard and API

### DIFF
--- a/night_watcher_dashboard.html
+++ b/night_watcher_dashboard.html
@@ -442,6 +442,54 @@
         .test-results {
             margin-top: 1rem;
         }
+
+        .timeline-container {
+            background: #1a202c;
+            border-radius: 8px;
+            padding: 1rem;
+            margin: 1rem 0;
+            overflow-x: auto;
+        }
+
+        .event-node {
+            display: inline-block;
+            width: 60px;
+            height: 60px;
+            border-radius: 50%;
+            margin: 0 10px;
+            cursor: pointer;
+            transition: all 0.3s;
+        }
+
+        .event-node.cross-source {
+            border: 3px solid #f6ad55;
+        }
+
+        .event-node.high-urgency {
+            background: #e53e3e;
+            animation: pulse 2s infinite;
+        }
+
+        .campaign-card {
+            background: #4a5568;
+            border-radius: 8px;
+            padding: 1rem;
+            margin: 0.5rem 0;
+            border-left: 4px solid #e53e3e;
+        }
+
+        .pattern-indicator {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            border-radius: 20px;
+            margin: 0.25rem;
+            font-size: 0.9rem;
+        }
+
+        .pattern-indicator.active {
+            background: #d69e2e;
+            color: white;
+        }
     </style>
 </head>
 <body>
@@ -464,6 +512,10 @@
             </div>
             <div class="nav-item" onclick="showSection('vector-store')">
                 🧠 Vector Store
+            </div>
+            <div class="nav-item" onclick="showSection('events')">
+                📊 Event Intelligence
+                <span class="nav-badge" id="event-count" style="display: none;">0</span>
             </div>
             <div class="nav-item" onclick="showSection('export')">
                 📦 Export & Distribution
@@ -773,6 +825,62 @@
                     <div class="log-entry info">[INFO] Export system ready</div>
                 </div>
         </div>
+
+            <!-- Event Intelligence Section -->
+            <div id="events" class="section">
+                <h2>Event Intelligence &amp; Pattern Analysis</h2>
+
+                <!-- Status Cards -->
+                <div class="status-grid">
+                    <div class="status-card">
+                        <h4>Unique Events</h4>
+                        <div class="value" id="unique-events">0</div>
+                    </div>
+                    <div class="status-card">
+                        <h4>Cross-Source Events</h4>
+                        <div class="value" id="cross-source-events">0</div>
+                    </div>
+                    <div class="status-card">
+                        <h4>Active Campaigns</h4>
+                        <div class="value" id="active-campaigns">0</div>
+                    </div>
+                    <div class="status-card">
+                        <h4>Threat Level</h4>
+                        <div class="value" id="threat-level">Low</div>
+                    </div>
+                </div>
+
+                <!-- Controls -->
+                <div class="control-panel">
+                    <h3>Event Aggregation</h3>
+                    <div class="form-group">
+                        <label>Analysis Window (days)</label>
+                        <input type="number" id="analysis-window" value="7" min="1" max="30">
+                    </div>
+                    <button class="btn btn-primary" onclick="runEventAggregation()">Aggregate Events</button>
+                    <button class="btn btn-warning" onclick="viewLatestAggregation()">View Latest</button>
+                </div>
+
+                <!-- Event Timeline -->
+                <div id="event-timeline" class="timeline-container"></div>
+
+                <!-- Pattern Analysis -->
+                <div id="pattern-analysis" class="analysis-container">
+                    <h3>Cross-Source Patterns</h3>
+                </div>
+
+                <!-- Campaign Tracker -->
+                <div id="campaign-tracker" class="campaign-container">
+                    <h3>Coordinated Campaigns</h3>
+                </div>
+
+                <!-- Urgency Matrix -->
+                <div id="urgency-matrix" class="urgency-container">
+                    <h3>Event Urgency Analysis</h3>
+                </div>
+                <div class="log-container" id="event-log"></div>
+            </div>
+        </div>
     </div>
 
     <script>
@@ -874,6 +982,28 @@
                 updateElement('pending-review', status.pending_review || 0);
                 updateElement('review-queue-count', status.pending_review || 0);
                 updateElement('pending-analysis-2', status.pending_analysis || 0);
+
+                if (status.event_stats) {
+                    updateElement('unique-events', status.event_stats.unique_events || 0);
+                    updateElement('cross-source-events', status.event_stats.cross_source_events || 0);
+                    updateElement('active-campaigns', status.event_stats.active_campaigns || 0);
+                    const threat = calculateThreatLevel(status.event_stats);
+                    const threatElem = document.getElementById('threat-level');
+                    if (threatElem) {
+                        threatElem.textContent = threat;
+                        threatElem.style.color = getThreatColor(threat);
+                    }
+
+                    const badgeEv = document.getElementById('event-count');
+                    if (badgeEv) {
+                        if (status.event_stats.active_campaigns > 0) {
+                            badgeEv.textContent = status.event_stats.active_campaigns;
+                            badgeEv.style.display = 'flex';
+                        } else {
+                            badgeEv.style.display = 'none';
+                        }
+                    }
+                }
                 
                 // Update review badge
                 const reviewCount = status.pending_review || 0;
@@ -1738,6 +1868,103 @@
                 }
             } catch (error) {
                 logMessage('export-log', 'error', `Export error: ${error.message}`);
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // Event aggregation functions
+        // ---------------------------------------------------------------
+        async function runEventAggregation() {
+            const window = document.getElementById('analysis-window').value;
+            try {
+                const result = await apiCall('/aggregate-events', {
+                    method: 'POST',
+                    body: JSON.stringify({ analysis_window: parseInt(window) })
+                });
+
+                updateEventStats(result);
+                renderEventTimeline(result.events || []);
+                renderPatternAnalysis(result.pattern_analysis || {});
+                renderCampaigns(result.coordinated_campaigns || []);
+
+                logMessage('event-log', 'success', `Aggregated ${result.unique_events} events from ${result.analyses_processed} analyses`);
+            } catch (error) {
+                logMessage('event-log', 'error', `Aggregation failed: ${error.message}`);
+            }
+        }
+
+        function viewLatestAggregation() {
+            apiCall('/events/latest').then(res => {
+                updateEventStats(res);
+                renderEventTimeline(res.events || []);
+                renderPatternAnalysis(res.pattern_analysis || {});
+                renderCampaigns(res.coordinated_campaigns || []);
+            }).catch(err => {
+                logMessage('event-log', 'error', `Load failed: ${err.message}`);
+            });
+        }
+
+        function updateEventStats(data) {
+            document.getElementById('unique-events').textContent = data.unique_events || 0;
+            document.getElementById('cross-source-events').textContent = data.cross_source_events || 0;
+            document.getElementById('active-campaigns').textContent = (data.coordinated_campaigns || []).length;
+
+            const threatLevel = calculateThreatLevel(data);
+            const threatElem = document.getElementById('threat-level');
+            threatElem.textContent = threatLevel;
+            threatElem.style.color = getThreatColor(threatLevel);
+        }
+
+        function renderEventTimeline(events) {
+            const container = document.getElementById('event-timeline');
+            container.innerHTML = '';
+            events.sort((a,b) => (a.date || '').localeCompare(b.date || ''));
+            events.forEach(ev => {
+                const node = document.createElement('div');
+                node.className = 'event-node';
+                if (ev.cross_source_analysis && ev.cross_source_analysis.source_count > 1) node.classList.add('cross-source');
+                if ((ev.urgency_score || 0) >= 7) node.classList.add('high-urgency');
+                node.title = ev.name;
+                container.appendChild(node);
+            });
+        }
+
+        function renderPatternAnalysis(patterns) {
+            const container = document.getElementById('pattern-analysis');
+            container.innerHTML = '<h3>Cross-Source Patterns</h3>';
+            for (const [key, value] of Object.entries(patterns)) {
+                const span = document.createElement('span');
+                span.className = 'pattern-indicator active';
+                span.textContent = `${key}: ${JSON.stringify(value)}`;
+                container.appendChild(span);
+            }
+        }
+
+        function renderCampaigns(campaigns) {
+            const container = document.getElementById('campaign-tracker');
+            container.innerHTML = '<h3>Coordinated Campaigns</h3>';
+            campaigns.forEach(c => {
+                const card = document.createElement('div');
+                card.className = 'campaign-card';
+                card.textContent = `${c.id || ''} - ${c.events ? c.events.length : 0} events`;
+                container.appendChild(card);
+            });
+        }
+
+        function calculateThreatLevel(data) {
+            const score = data.authoritarian_escalation?.overall_threat_level || data.threat_level || 0;
+            if (score > 7) return 'High';
+            if (score > 4) return 'Moderate';
+            if (score > 2) return 'Elevated';
+            return 'Low';
+        }
+
+        function getThreatColor(level) {
+            switch(level) {
+                case 'High': return '#e53e3e';
+                case 'Moderate': return '#d69e2e';
+                case 'Elevated': return '#f6ad55';
+                default: return '#68d391';
             }
         }
 


### PR DESCRIPTION
## Summary
- add event aggregation caching and endpoints in web server
- include event stats in status endpoint
- extend dashboard with Event Intelligence section
- add event visualization CSS and JS helpers

## Testing
- `pytest -q` *(fails: Can't load the model for 'sentence-transformers/all-MiniLM-L6-v2')*

------
https://chatgpt.com/codex/tasks/task_e_685630ef727883328254efc193341733