### PR TITLE
Fix bias correlation default set

### DIFF
--- a/event_aggregator.py
+++ b/event_aggregator.py
@@ -680,7 +680,10 @@ class EventAggregator:
     
     def _analyze_bias_correlation(self, events: List[Dict]) -> Dict[str, Any]:
         """Analyze how bias correlates with event reporting."""
-        bias_patterns = defaultdict(lambda: defaultdict(int))
+        # Track how many events each bias reports and which sources mention
+        # those events. The default entry contains a count and a set for
+        # storing unique sources.
+        bias_patterns = defaultdict(lambda: {"event_count": 0, "sources": set()})
         
         for event in events:
             if "source_perspectives" in event:


### PR DESCRIPTION
## Summary
- fix default value for bias correlation analysis

## Testing
- `pytest -q` *(fails: Can't load the model for 'sentence-transformers/all-MiniLM-L6-v2')*

------
https://chatgpt.com/codex/tasks/task_e_6859856b8984833291d49432ac762b64