### PR TITLE
Add citation tracking system

### DIFF
--- a/knowledge_graph.py
+++ b/knowledge_graph.py
@@ -723,10 +723,13 @@ class KnowledgeGraph:
                     continue
 
                 # Add node to graph
+                node_attrs = node.get("attributes", {}).copy()
+                if node.get("citations"):
+                    node_attrs["citations"] = node.get("citations")
                 node_id = self.add_node(
                     node_type=node.get("node_type"),
                     name=node.get("name"),
-                    attributes=node.get("attributes", {}),
+                    attributes=node_attrs,
                     timestamp=node.get("timestamp", publication_date),
                     source_document_id=document_id,
                     source_sentence=node.get("source_sentence")
@@ -754,6 +757,9 @@ class KnowledgeGraph:
                     continue
 
                 # Add edge to graph
+                edge_attrs = edge.get("attributes", {}).copy()
+                if edge.get("citations"):
+                    edge_attrs["citations"] = edge.get("citations")
                 self.add_edge(
                     source_id=source_id,
                     relation=edge.get("relation"),
@@ -761,7 +767,7 @@ class KnowledgeGraph:
                     timestamp=edge.get("timestamp", publication_date),
                     evidence_quote=edge.get("evidence_quote"),
                     source_document_id=document_id,
-                    attributes=edge.get("attributes", {})
+                    attributes=edge_attrs
                 )
                 edges_added += 1
 


### PR DESCRIPTION
## Summary
- track document_id and initialize citation summary in `ContentAnalyzer`
- integrate `add_citations()` step into round processing
- provide `add_citations()` implementation for basic exact matches
- store citations when building knowledge graph nodes and edges

## Testing
- `pytest -q` *(fails: Can't load the model for 'sentence-transformers/all-MiniLM-L6-v2')*

------
https://chatgpt.com/codex/tasks/task_e_685b2a0b8c4c83329664810d566b93dc