### PR TITLE
Enhance event similarity logic

### DIFF
--- a/tests/test_event_similarity.py
+++ b/tests/test_event_similarity.py
@@ -1,0 +1,34 @@
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from event_aggregator import EventAggregator
+
+
+def test_event_similarity_basic():
+    agg = EventAggregator(similarity_threshold=0.7)
+    e1 = {
+        "name": "Protest in Washington",
+        "date": "2025-06-01",
+        "attributes": {"location": "Washington DC, USA", "description": "Mass protest"},
+    }
+    e2 = {
+        "name": "Protest rally Washington",
+        "date": "2025-06-01",
+        "attributes": {"location": "Washington, DC, USA", "description": "Large protest"},
+    }
+    assert agg._events_similar(e1, e2)
+
+
+def test_event_similarity_temporal():
+    agg = EventAggregator(similarity_threshold=0.7)
+    e1 = {"name": "Court ruling", "date": "2025-06-01", "attributes": {"location": "NY, USA"}}
+    e2 = {"name": "Court ruling", "date": "2025-06-02", "attributes": {"location": "NY, USA"}}
+    assert agg._events_similar(e1, e2)
+
+
+def test_event_similarity_distant_dates():
+    agg = EventAggregator(similarity_threshold=0.8)
+    e1 = {"name": "Election results", "date": "2025-06-01", "attributes": {"location": "CA, USA"}}
+    e2 = {"name": "Election results", "date": "2025-06-10", "attributes": {"location": "CA, USA"}}
+    assert not agg._events_similar(e1, e2)


### PR DESCRIPTION
## Summary
- refine event similarity detection with fuzzy matching
- add temporal and location-based scoring
- provide helper functions for fuzzy ratio and scoring
- add unit tests for event similarity cases

## Testing
- `pytest tests/test_event_similarity.py -q`
- `pytest -q` *(fails: OSError: Can't load the model for 'sentence-transformers/all-MiniLM-L6-v2')*

------
https://chatgpt.com/codex/tasks/task_e_685c61566aec8332a44a2fa863f4bcc6