### PR TITLE
Improve government scraping with official APIs

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -25,9 +25,9 @@ from bs4 import BeautifulSoup
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 from gov_scrapers import (
-    scrape_federal_register,
-    scrape_white_house_actions,
-    scrape_congress_bills,
+    fetch_federal_register_api,
+    fetch_white_house_actions_api,
+    fetch_govinfo_bills_api,
 )
 
 # Optional imports
@@ -150,6 +150,8 @@ class ContentCollector:
         self.use_google_news = cc.get("use_google_news", True)
         self.use_gdelt = cc.get("use_gdelt", True)
         self.use_gov_scrapers = cc.get("use_gov_scrapers", True)
+        self.gov_article_limit = cc.get("gov_scraper_limit", self.article_limit)
+        self.govinfo_api_key = cc.get("govinfo_api_key")
 
         self.cancelled = False
         
@@ -1359,7 +1361,7 @@ class ContentCollector:
 
         # Federal Register
         try:
-            fr_docs = scrape_federal_register(start_date, end_date, limit=50)
+            fr_docs = fetch_federal_register_api(start_date, end_date, limit=self.gov_article_limit)
             for doc in fr_docs:
                 doc["via_gov_scraper"] = True
                 articles.append(doc)
@@ -1370,7 +1372,7 @@ class ContentCollector:
 
         # White House presidential actions
         try:
-            wh_docs = scrape_white_house_actions(start_date, end_date, limit=50)
+            wh_docs = fetch_white_house_actions_api(start_date, end_date, limit=self.gov_article_limit)
             for doc in wh_docs:
                 doc["via_gov_scraper"] = True
                 articles.append(doc)
@@ -1381,7 +1383,7 @@ class ContentCollector:
 
         # Congress bills
         try:
-            bill_docs = scrape_congress_bills(start_date, end_date, limit=50)
+            bill_docs = fetch_govinfo_bills_api(start_date, end_date, api_key=self.govinfo_api_key, limit=self.gov_article_limit)
             for doc in bill_docs:
                 doc["via_gov_scraper"] = True
                 articles.append(doc)

--- a/config.json
+++ b/config.json
@@ -4,6 +4,8 @@
     "use_google_news": true,
     "use_gdelt": true,
     "use_gov_scrapers": true,
+    "gov_scraper_limit": 200,
+    "govinfo_api_key": "DEMO_KEY",
     "sources": [
       {
         "url": "https://api.gdeltproject.org/api/v2/doc/doc?query=white%20house%20OR%20congress%20OR%20supreme%20court&mode=artlist&format=rss&maxrecords=250",

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -2,6 +2,7 @@ import os
 import tarfile
 import tempfile
 import sys
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
@@ -9,22 +10,32 @@ from export_artifact import export_artifact
 from update_artifact import apply_update
 
 
+class DummyModel:
+    def get_sentence_embedding_dimension(self):
+        return 4
+
+    def encode(self, texts, show_progress_bar=False):
+        import numpy as np
+        return np.zeros((len(texts), 4), dtype="float32")
+
+
 def test_export_and_update_cycle():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        kg_dir = os.path.join(tmpdir, "kg")
-        vec_dir = os.path.join(tmpdir, "vec")
-        doc_dir = os.path.join(tmpdir, "docs")
-        os.makedirs(kg_dir, exist_ok=True)
-        os.makedirs(vec_dir, exist_ok=True)
-        os.makedirs(doc_dir, exist_ok=True)
+    with patch("vector_store.SentenceTransformer", return_value=DummyModel()):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            kg_dir = os.path.join(tmpdir, "kg")
+            vec_dir = os.path.join(tmpdir, "vec")
+            doc_dir = os.path.join(tmpdir, "docs")
+            os.makedirs(kg_dir, exist_ok=True)
+            os.makedirs(vec_dir, exist_ok=True)
+            os.makedirs(doc_dir, exist_ok=True)
 
-        archive = os.path.join(tmpdir, "bundle.tar.gz")
-        export_artifact(archive, kg_dir=kg_dir, vector_dir=vec_dir, documents_dir=doc_dir)
+            archive = os.path.join(tmpdir, "bundle.tar.gz")
+            export_artifact(archive, kg_dir=kg_dir, vector_dir=vec_dir, documents_dir=doc_dir)
 
-        assert os.path.exists(archive)
-        with tarfile.open(archive, "r:gz") as t:
-            basenames = [os.path.basename(m) for m in t.getnames()]
-        assert "manifest.json" in basenames
+            assert os.path.exists(archive)
+            with tarfile.open(archive, "r:gz") as t:
+                basenames = [os.path.basename(m) for m in t.getnames()]
+            assert "manifest.json" in basenames
 
-        apply_update(archive, kg_dir=kg_dir, vector_dir=vec_dir, documents_dir=doc_dir)
-        assert os.path.exists(os.path.join(vec_dir, "metadata.json"))
+            apply_update(archive, kg_dir=kg_dir, vector_dir=vec_dir, documents_dir=doc_dir)
+            assert os.path.exists(os.path.join(vec_dir, "metadata.json"))

--- a/tests/test_gov_scrapers.py
+++ b/tests/test_gov_scrapers.py
@@ -1,0 +1,48 @@
+import sys
+import os
+import json
+from datetime import datetime
+from unittest.mock import patch, Mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from gov_scrapers import (
+    fetch_federal_register_api,
+    fetch_white_house_actions_api,
+    fetch_govinfo_bills_api,
+)
+
+
+def _mock_response(json_data):
+    mock_resp = Mock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = json_data
+    return mock_resp
+
+
+def test_fetch_federal_register_api():
+    sample = {"results": [{"title": "Test FR", "html_url": "u", "abstract": "a", "publication_date": "2025-01-01"}]}
+    with patch("requests.get", return_value=_mock_response(sample)) as pg:
+        docs = fetch_federal_register_api(datetime(2025,1,1), datetime(2025,1,2), limit=1)
+        assert len(docs) == 1
+        assert docs[0]["title"] == "Test FR"
+        pg.assert_called()
+
+
+def test_fetch_white_house_actions_api():
+    sample = [{"title": {"rendered": "WH"}, "link": "https://www.whitehouse.gov/briefing-room/presidential-actions/test", "excerpt": {"rendered": "<p>x</p>"}, "date": "2025-01-02T00:00:00"}]
+    with patch("requests.get", return_value=_mock_response(sample)) as pg:
+        docs = fetch_white_house_actions_api(datetime(2025,1,1), datetime(2025,1,3), limit=1)
+        assert len(docs) == 1
+        assert "whitehouse.gov" in docs[0]["url"]
+        pg.assert_called()
+
+
+def test_fetch_govinfo_bills_api():
+    sample = {"packages": [{"title": "Bill", "packageLink": "https://x", "lastModified": "2025-01-03"}]}
+    with patch("requests.get", return_value=_mock_response(sample)) as pg:
+        docs = fetch_govinfo_bills_api(datetime(2025,1,1), datetime(2025,1,5), api_key="KEY", limit=1)
+        assert len(docs) == 1
+        assert docs[0]["source"] == "Congress.gov"
+        pg.assert_called()
+


### PR DESCRIPTION
## Summary
- expand config to include gov scraper limit and API key
- upgrade government scraping to use official JSON APIs
- adjust ContentCollector for configurable government limits
- add unit tests for new scrapers
- stub SentenceTransformer in artifact test for offline testing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e1364c77c83328bdbf15be32b594b