### PR TITLE
Restore HTML scrapers and tune limits

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -28,6 +28,9 @@ from gov_scrapers import (
     fetch_federal_register_api,
     fetch_white_house_actions_api,
     fetch_govinfo_bills_api,
+    scrape_federal_register,
+    scrape_white_house_actions,
+    scrape_congress_bills,
 )
 
 # Optional imports
@@ -1361,7 +1364,7 @@ class ContentCollector:
 
         # Federal Register
         try:
-            fr_docs = fetch_federal_register_api(start_date, end_date, limit=self.gov_article_limit)
+            fr_docs = scrape_federal_register(start_date, end_date, limit=self.gov_article_limit)
             for doc in fr_docs:
                 doc["via_gov_scraper"] = True
                 articles.append(doc)
@@ -1372,7 +1375,7 @@ class ContentCollector:
 
         # White House presidential actions
         try:
-            wh_docs = fetch_white_house_actions_api(start_date, end_date, limit=self.gov_article_limit)
+            wh_docs = scrape_white_house_actions(start_date, end_date, limit=self.gov_article_limit)
             for doc in wh_docs:
                 doc["via_gov_scraper"] = True
                 articles.append(doc)
@@ -1383,7 +1386,7 @@ class ContentCollector:
 
         # Congress bills
         try:
-            bill_docs = fetch_govinfo_bills_api(start_date, end_date, api_key=self.govinfo_api_key, limit=self.gov_article_limit)
+            bill_docs = scrape_congress_bills(start_date, end_date, limit=self.gov_article_limit)
             for doc in bill_docs:
                 doc["via_gov_scraper"] = True
                 articles.append(doc)

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "content_collection": {
-    "article_limit": 500,
+    "article_limit": 200,
     "use_google_news": true,
     "use_gdelt": true,
     "use_gov_scrapers": true,
@@ -13,7 +13,7 @@
         "name": "GDELT Comprehensive Politics",
         "bias": "aggregate",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.federalregister.gov/api/v1/documents.rss?conditions[publication_date][gte]=2025-01-20",
@@ -21,7 +21,7 @@
         "name": "Federal Register Complete",
         "bias": "official",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.govinfo.gov/rss/bills.xml",
@@ -29,7 +29,7 @@
         "name": "GovInfo Bills Feed",
         "bias": "official",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.memeorandum.com/feed.xml",
@@ -37,7 +37,7 @@
         "name": "Memeorandum Politics",
         "bias": "aggregate",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://rss.app/feeds/8ZLRA1MIdInNK9TW.xml",
@@ -46,7 +46,7 @@
         "name": "AP News Politics",
         "site_domain": "apnews.com",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://feeds.npr.org/1004/rss.xml",
@@ -55,7 +55,7 @@
         "name": "NPR Politics",
         "site_domain": "npr.org",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.politico.com/rss/politicopicks.xml",
@@ -64,7 +64,7 @@
         "name": "Politico Top Picks",
         "site_domain": "politico.com",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://thehill.com/feed/",
@@ -73,7 +73,7 @@
         "name": "The Hill",
         "site_domain": "thehill.com",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.reuters.com/world/us/rss",
@@ -82,7 +82,7 @@
         "name": "Reuters US",
         "site_domain": "reuters.com",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.propublica.org/feeds/propublica/main",
@@ -91,7 +91,7 @@
         "name": "ProPublica",
         "site_domain": "propublica.org",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.democracynow.org/democracynow.rss",
@@ -100,7 +100,7 @@
         "name": "Democracy Now",
         "site_domain": "democracynow.org",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://reason.com/feed/",
@@ -109,7 +109,7 @@
         "name": "Reason Magazine",
         "site_domain": "reason.com",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.whitehouse.gov/briefing-room/statements-releases/feed/",
@@ -118,7 +118,7 @@
         "name": "White House Press Releases",
         "site_domain": "whitehouse.gov",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.supremecourt.gov/rss/opinions.xml",
@@ -127,7 +127,7 @@
         "name": "Supreme Court Opinions",
         "site_domain": "supremecourt.gov",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.justice.gov/feeds/press_releases/rss.xml",
@@ -136,7 +136,7 @@
         "name": "DOJ Press Releases",
         "site_domain": "justice.gov",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.cnn.com/politics",
@@ -145,7 +145,7 @@
         "name": "CNN Politics (Archive)",
         "archive_url": "https://www.cnn.com/politics",
         "enabled": false,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.foxnews.com/politics",
@@ -154,7 +154,7 @@
         "name": "Fox News Politics (Archive)",
         "archive_url": "https://www.foxnews.com/politics",
         "enabled": false,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.washingtonpost.com/sitemap/politics/",
@@ -163,7 +163,7 @@
         "name": "Washington Post Politics",
         "sitemap_url": "https://www.washingtonpost.com/sitemap-index.xml",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.nytimes.com/sitemaps/sitemap_news.xml.gz",
@@ -171,7 +171,7 @@
         "bias": "center-left",
         "name": "New York Times",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.theguardian.com/us-news/rss",
@@ -179,7 +179,7 @@
         "bias": "center-left",
         "name": "The Guardian US",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.wsj.com/xml/rss/3_7085.xml",
@@ -187,7 +187,7 @@
         "bias": "center-right",
         "name": "Wall Street Journal Politics",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.axios.com/feeds/politics.xml",
@@ -195,7 +195,7 @@
         "bias": "center",
         "name": "Axios Politics",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.vox.com/rss/policy-and-politics/index.xml",
@@ -203,7 +203,7 @@
         "bias": "center-left",
         "name": "Vox Policy & Politics",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.buzzfeednews.com/section/politics.xml",
@@ -211,7 +211,7 @@
         "bias": "center-left",
         "name": "BuzzFeed News Politics",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.nbcnews.com/politics",
@@ -220,7 +220,7 @@
         "name": "NBC News Politics (Archive)",
         "archive_url": "https://www.nbcnews.com/politics",
         "enabled": false,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://abcnews.go.com/Politics",
@@ -229,7 +229,7 @@
         "name": "ABC News Politics (Archive)",
         "archive_url": "https://abcnews.go.com/Politics",
         "enabled": false,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.cbsnews.com/politics/",
@@ -238,7 +238,7 @@
         "name": "CBS News Politics (Archive)",
         "archive_url": "https://www.cbsnews.com/politics/",
         "enabled": false,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.uscourts.gov/news/rss/all",
@@ -246,7 +246,7 @@
         "bias": "official",
         "name": "US Courts News",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.congress.gov/rss/most-viewed-bills.xml",
@@ -254,7 +254,7 @@
         "bias": "official",
         "name": "Congress Most Viewed Bills",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.state.gov/rss-feed/",
@@ -262,7 +262,7 @@
         "bias": "official",
         "name": "State Department",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.defense.gov/DesktopModules/ArticleCS/RSS.ashx?max=10&ContentType=1&Site=945",
@@ -270,7 +270,7 @@
         "bias": "official",
         "name": "Department of Defense",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.dhs.gov/news_and_updates/rss.xml",
@@ -278,7 +278,7 @@
         "bias": "official",
         "name": "Homeland Security",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://theintercept.com/feed/?lang=en",
@@ -286,7 +286,7 @@
         "bias": "left",
         "name": "The Intercept",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.motherjones.com/politics/feed/",
@@ -294,7 +294,7 @@
         "bias": "left",
         "name": "Mother Jones Politics",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.breitbart.com/politics/feed/",
@@ -302,7 +302,7 @@
         "bias": "right",
         "name": "Breitbart Politics",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.nationalreview.com/feed/",
@@ -310,7 +310,7 @@
         "bias": "right",
         "name": "National Review",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://fivethirtyeight.com/politics/feed/",
@@ -318,7 +318,7 @@
         "bias": "center",
         "name": "FiveThirtyEight Politics",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://www.realclearpolitics.com/index.xml",
@@ -326,7 +326,7 @@
         "bias": "center-right",
         "name": "RealClearPolitics",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://news.google.com/rss/search?q=site:cnn.com+politics+after:2025-01-20&hl=en-US&gl=US&ceid=US:en",
@@ -334,7 +334,7 @@
         "name": "CNN via Google News",
         "bias": "center-left",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://news.google.com/rss/search?q=site:foxnews.com+politics+after:2025-01-20&hl=en-US&gl=US&ceid=US:en",
@@ -342,7 +342,7 @@
         "name": "Fox News via Google News",
         "bias": "right",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://news.google.com/rss/search?q=white+house+executive+order+after:2025-01-20&hl=en-US&gl=US&ceid=US:en",
@@ -350,7 +350,7 @@
         "name": "Executive Orders Search",
         "bias": "aggregate",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       },
       {
         "url": "https://news.google.com/rss/search?q=congress+legislation+passed+after:2025-01-20&hl=en-US&gl=US&ceid=US:en",
@@ -358,7 +358,7 @@
         "name": "Congressional Activity",
         "bias": "aggregate",
         "enabled": true,
-        "limit": 500
+        "limit": 200
       }
     ],
     "govt_keywords": [


### PR DESCRIPTION
## Summary
- use HTML-based government scrapers again
- lower collection limits for efficiency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686da0500c1483329a3e7635c8360d43