### PR TITLE
Relax filter and improve feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ python Night_Watcher.py --web
 - **Web dashboard** for monitoring and control
 - **Cryptographic provenance** to prevent tampering
 - **Automatic archival retrieval** when collecting older dates
+- **Google News search retrieves up to 100 results per query**
+- **Articles flagged political with one keyword match**
 
 ## 🔧 Command Line Usage
 

--- a/collector.py
+++ b/collector.py
@@ -1098,7 +1098,8 @@ class ContentCollector:
         """Check if content is political with logging."""
         text = f"{title} {content}".lower()
         matches = [kw for kw in self.govt_keywords if kw in text]
-        is_political = len(matches) >= 2
+        # Relax threshold to a single keyword match
+        is_political = len(matches) >= 1
         
         self.logger.debug(f"Political check: {len(matches)} keyword matches ({'political' if is_political else 'not political'})")
         if matches:
@@ -1166,7 +1167,10 @@ class ContentCollector:
             try:
                 # Build Google News RSS URL with date filter
                 encoded_query = quote(f'{query} after:{start_str} before:{end_str}')
-                google_news_url = f"https://news.google.com/rss/search?q={encoded_query}&hl=en-US&gl=US&ceid=US:en"
+                google_news_url = (
+                    f"https://news.google.com/rss/search?q={encoded_query}"
+                    "&hl=en-US&gl=US&ceid=US:en&num=100"
+                )
                 
                 self.logger.debug(f"Google News URL: {google_news_url}")
                 
@@ -1177,7 +1181,7 @@ class ContentCollector:
                 self.logger.debug(f"Google News returned {entries_found} entries for query '{query}'")
                 
                 articles_from_query = 0
-                for entry in feed.entries[:20]:  # Limit per query
+                for entry in feed.entries:
                     if self.cancelled:
                         break
                         

--- a/config.json
+++ b/config.json
@@ -40,10 +40,10 @@
         "limit": 200
       },
       {
-        "url": "https://rss.app/feeds/8ZLRA1MIdInNK9TW.xml",
+        "url": "https://news.google.com/rss/search?q=site:apnews.com+politics&hl=en-US&gl=US&ceid=US:en",
         "type": "rss",
         "bias": "center",
-        "name": "AP News Politics",
+        "name": "AP News via Google",
         "site_domain": "apnews.com",
         "enabled": true,
         "limit": 200
@@ -58,10 +58,10 @@
         "limit": 200
       },
       {
-        "url": "https://www.politico.com/rss/politicopicks.xml",
+        "url": "https://news.google.com/rss/search?q=site:politico.com+politics&hl=en-US&gl=US&ceid=US:en",
         "type": "rss",
         "bias": "center",
-        "name": "Politico Top Picks",
+        "name": "Politico via Google",
         "site_domain": "politico.com",
         "enabled": true,
         "limit": 200
@@ -76,10 +76,10 @@
         "limit": 200
       },
       {
-        "url": "https://www.reuters.com/world/us/rss",
+        "url": "https://news.google.com/rss/search?q=site:reuters.com+us+politics&hl=en-US&gl=US&ceid=US:en",
         "type": "rss",
         "bias": "center",
-        "name": "Reuters US",
+        "name": "Reuters via Google",
         "site_domain": "reuters.com",
         "enabled": true,
         "limit": 200


### PR DESCRIPTION
## Summary
- relax political keyword threshold
- fix failing feeds with Google News alternatives
- expand Google News historical search to 100 results
- document new collection tweaks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f1e010f58833291699bb696341e67