### PR TITLE
Improve collector filtering and feeds

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -156,7 +156,7 @@ class ContentCollector:
         self.gov_article_limit = cc.get("gov_scraper_limit", self.article_limit)
         self.govinfo_api_key = cc.get("govinfo_api_key")
 
-        self.political_threshold = cc.get("political_threshold", 2)
+        self.political_threshold = cc.get("political_threshold", 1)
         self.google_news_results_per_query = cc.get("google_news_results_per_query", 20)
 
         self.cancelled = False

--- a/config.json
+++ b/config.json
@@ -130,7 +130,7 @@
         "limit": 200
       },
       {
-        "url": "https://www.justice.gov/feeds/press_releases/rss.xml",
+        "url": "https://www.justice.gov/justice-news/rss.xml",
         "type": "rss",
         "bias": "official",
         "name": "DOJ Press Releases",
@@ -190,7 +190,7 @@
         "limit": 200
       },
       {
-        "url": "https://www.axios.com/feeds/politics.xml",
+        "url": "https://www.axios.com/politics/feed",
         "type": "rss",
         "bias": "center",
         "name": "Axios Politics",
@@ -241,7 +241,7 @@
         "limit": 200
       },
       {
-        "url": "https://www.uscourts.gov/news/rss/all",
+        "url": "https://www.uscourts.gov/taxonomy/term/15/feed",
         "type": "rss",
         "bias": "official",
         "name": "US Courts News",
@@ -273,7 +273,7 @@
         "limit": 200
       },
       {
-        "url": "https://www.dhs.gov/news_and_updates/rss.xml",
+        "url": "https://www.dhs.gov/news-releases/feed",
         "type": "rss",
         "bias": "official",
         "name": "Homeland Security",
@@ -461,7 +461,7 @@
       "state of emergency"
     ],
     "political_threshold": 1,
-    "google_news_results_per_query": 50,
+    "google_news_results_per_query": 100,
     "request_timeout": 45,
     "delay_between_requests": 2.0
   },


### PR DESCRIPTION
## Summary
- relax political threshold default to 1
- update RSS feed URLs for DOJ, US Courts, DHS and Axios
- bump Google News results per query to 100

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68707654cff88332b72f03a3eba801e4