### PR TITLE
Improve collection count updates

### DIFF
--- a/night_watcher_dashboard.html
+++ b/night_watcher_dashboard.html
@@ -541,6 +541,10 @@
                         <div class="value" id="pending-analysis">0</div>
                     </div>
                     <div class="status-card">
+                        <h4>Articles Collected</h4>
+                        <div class="value" id="articles-collected">0</div>
+                    </div>
+                    <div class="status-card">
                         <h4>LLM Status</h4>
                         <div class="value" id="llm-status">Unknown</div>
                     </div>
@@ -1056,11 +1060,11 @@
         async function updateTaskStatus() {
             try {
                 const taskStatus = await apiCall('/task-status');
-                
+
                 // Update progress bar
-                const progress = data.progress || 0;
+                const progress = taskStatus.progress || 0;
                 document.getElementById('task-progress').style.width = progress + '%';
-                if (data.task === 'analysis') {
+                if (taskStatus.task === 'analysis') {
                     document.getElementById('analysis-progress').style.width = progress + '%';
                 }
                 
@@ -1088,6 +1092,11 @@
                     if (taskStatus.task === 'analysis') {
                         analyzerContainer.scrollTop = analyzerContainer.scrollHeight;
                     }
+                }
+
+                const countElem = document.getElementById('articles-collected');
+                if (countElem) {
+                    countElem.textContent = taskStatus.articles_collected || 0;
                 }
                 
                 // Stop polling if task is done

--- a/night_watcher_web.py
+++ b/night_watcher_web.py
@@ -32,7 +32,13 @@ CORS(app)
 night_watcher = None
 current_task = None
 task_thread = None
-task_status = {"running": False, "task": None, "progress": 0, "messages": []}
+task_status = {
+    "running": False,
+    "task": None,
+    "progress": 0,
+    "messages": [],
+    "articles_collected": 0,
+}
 
 # Statistics cache
 stats_cache = {"last_update": None, "data": {}}
@@ -552,10 +558,12 @@ def api_collect():
         task_status["running"] = True
         task_status["task"] = "collection"
         task_status["progress"] = 0
+        task_status["articles_collected"] = 0
         add_log_message("info", f"Starting collection (mode: {mode})")
 
         def progress(event):
             if event.get("type") == "article":
+                task_status["articles_collected"] += 1
                 add_log_message("info", f"Collected: {event.get('title')}")
             elif event.get("type") == "error":
                 add_log_message(
@@ -841,6 +849,7 @@ def api_task_status():
             "running": task_status["running"],
             "task": task_status["task"],
             "progress": task_status["progress"],
+            "articles_collected": task_status.get("articles_collected", 0),
             "messages": task_status["messages"][-20:],  # Last 20 messages
         }
     )


### PR DESCRIPTION
## Summary
- track collected articles in the web server
- expose `articles_collected` via `/api/task-status`
- show an "Articles Collected" card on the dashboard
- fix task progress update logic and display article count in real time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871c93ef5908332bd7dac825b1c2e03